### PR TITLE
docs: full just-the-docs site + context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "OCCTSwiftMesh",
+  "description": "Mesh-domain algorithms for the OCCTSwift ecosystem. Adds quadric-error-metric (QEM) decimation that reports its achieved Hausdorff error, and planar cross-sectioning that recovers a slice's closed, nested contours like a 3D-printer slicer. Pure-Swift over OCCTSwift's Mesh type, robust on open / unwelded scan meshes.",
+  "folders": ["docs", "Sources/OCCTSwiftMesh"],
+  "excludeFolders": ["Tests", ".build"],
+  "rules": [
+    "Import both modules: `import OCCTSwift` (for the `Mesh` type and `Shape.mesh()`) and `import OCCTSwiftMesh` (for the algorithms).",
+    "The `Mesh` value type is declared in `OCCTSwift` and re-exported here; OCCTSwiftMesh adds its public surface as extension methods on `Mesh` plus the value types each algorithm returns — there is no free-standing API beyond the `OCCTSwiftMesh` namespace marker (which only carries `OCCTSwiftMesh.version`).",
+    "Decimate with `mesh.simplified(_:)` taking a `Mesh.SimplifyOptions`; it returns an optional `SimplifiedMesh` (`nil` on invalid options or empty input). Set EXACTLY ONE of `targetTriangleCount` (Int, in [1, input.triangleCount]) or `targetReduction` (Double fraction to remove, in [0,1]); both or neither returns nil. Optional `preserveBoundary` (default true), `preserveTopology` (default true, always honoured today), and `maxHausdorffDistance` (>= 0).",
+    "`SimplifiedMesh` reports `mesh`, `beforeTriangleCount`, `afterTriangleCount`, and `hausdorffDistance` (the achieved deviation, absolute, in input mesh units, reported on every successful call). `afterTriangleCount` is a soft target — it can overshoot the requested count when topology preservation or the Hausdorff cap stops collapsing early.",
+    "Slice with `mesh.crossSection(plane:minLoopArea:weld:)` taking a `CutPlane(point:normal:)` (normal need not be unit length; or `CutPlane.perpendicular(to:offset:)`). Returns an optional `MeshCrossSection` (`nil` if the plane misses the mesh).",
+    "A `MeshCrossSection` carries the plane basis (`origin`/`normal`/`uAxis`/`vAxis`), `contours: [MeshContour]` (closed loops), `openPaths` (polylines where the plane exits a boundary edge), `outerContours` (depth-0 loops), and `worldPoint(_:)` to lift a 2D (u,v) loop point back to 3D.",
+    "Each `MeshContour` is classified by NESTING, not triangle winding: `depth` (0 = outer solid boundary, 1 = hole/inner wall, ...), `isHole` (== depth % 2 == 1), `parent`, `signedArea` (CCW positive, normalized: even depth CCW, odd CW), `area`, `perimeter`, `bounds`, and `points` in plane (u,v) coordinates. A thin-walled tube slices into two separate nested loops — wall thickness is their offset.",
+    "Build a whole slicer layer stack with `mesh.crossSections(axis:through:spacing:margin:)`; `spacing` must be > 0, `margin` defaults to spacing/2 to inset the first/last slice off the end caps, and sections that miss the mesh are skipped."
+  ]
+}

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,17 @@
+# GitHub Pages (Jekyll) config for the OCCTSwiftMesh docs site — served from /docs on main.
+#
+# Theme: just-the-docs (left sidebar nav + search). Pinned to v0.3.3, the last release
+# compatible with GitHub Pages' native (no-Actions) build, which pins Jekyll 3.9.
+# Sidebar entries/order come from each page's `title` / `nav_order` front matter.
+title: OCCTSwiftMesh
+description: Mesh-domain algorithms (QEM decimation, planar cross-sections) for the OCCTSwift ecosystem.
+remote_theme: just-the-docs/just-the-docs@v0.3.3
+search_enabled: true
+heading_anchors: true
+aux_links:
+  "GitHub": ["https://github.com/SecondMouseAU/OCCTSwiftMesh"]
+aux_links_new_tab: true
+exclude:
+  - "*.sh"
+  - Gemfile
+  - Gemfile.lock

--- a/docs/guides/cookbook/cross-sections.md
+++ b/docs/guides/cookbook/cross-sections.md
@@ -1,0 +1,101 @@
+---
+title: Cross-Sections & Contours
+parent: Cookbook
+nav_order: 3
+---
+
+# Cross-Sections & Contours
+
+`Mesh.crossSection(plane:)` intersects a mesh with a plane and recovers the **closed contours**
+where the plane cuts the surface — the perimeter step a 3D-printer slicer performs. It's pure
+geometry over `Mesh.vertices` / `Mesh.indices` (no OCCT kernel calls), so it works directly on the
+**open / unwelded** meshes that raw STL and scan bodies actually are, where sewing to a B-Rep first
+would fail. The result is a [`MeshCrossSection`](../../reference/CrossSection.md).
+
+## Slice with a plane
+
+Build a [`CutPlane`](../../reference/CrossSection.md#cutplane) from a point and a normal (the normal
+need not be unit length — it's normalized internally). The call returns `nil` if the plane misses the
+mesh entirely:
+
+```swift
+import OCCTSwift
+import OCCTSwiftMesh
+
+guard let section = mesh.crossSection(
+    plane: CutPlane(point: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1))
+) else {
+    return   // plane missed the mesh
+}
+
+for c in section.contours {
+    let kind = c.isHole ? "hole" : "solid boundary"
+    print("depth \(c.depth) \(kind): \(c.points.count) pts, area \(c.area), perimeter \(c.perimeter)")
+}
+```
+
+There's a convenience constructor for the common axis-aligned case:
+
+```swift
+let plane = CutPlane.perpendicular(to: SIMD3(0, 0, 1), offset: 5)   // z = 5 plane
+let section = mesh.crossSection(plane: plane)
+```
+
+## Outer walls vs. holes come from nesting
+
+Each [`MeshContour`](../../reference/CrossSection.md#meshcontour) is classified by **nesting depth**,
+not by triangle winding — so it's reliable even on meshes with inconsistent orientation. `depth == 0`
+is an outermost solid boundary; `depth == 1` is a hole inside it (an inner wall or a pocket); deeper
+even/odd depths alternate solid/hole. `isHole` is just `depth % 2 == 1`, and orientation is
+normalized so solids are CCW (`signedArea > 0`) and holes CW.
+
+For a thin-walled tube the outer and inner walls come back as **two separate, nested loops**, so the
+wall thickness is simply their offset:
+
+```swift
+// Outermost loops only — the solid's outer boundary
+for outer in section.contours.filter({ $0.depth == 0 }) {
+    print("outer wall: area \(outer.area)")
+}
+// equivalently:
+let outers = section.outerContours
+```
+
+`MeshContour` also exposes `bounds` (axis-aligned `(min, max)` in plane coordinates) and `parent`
+(the index of the immediately enclosing loop, or `nil`).
+
+## Map contour points back to 3D
+
+Contour points are 2D `(u, v)` coordinates in the plane's basis. Lift them back to world space with
+`worldPoint(_:)`:
+
+```swift
+if let loop = section.contours.first {
+    let worldRing: [SIMD3<Double>] = loop.points.map { section.worldPoint($0) }
+    // worldRing now traces the loop in 3D, useful for re-lofting or display
+}
+```
+
+Where the plane exits the mesh through a boundary edge (cutting across an open end or a window rim),
+those segments come back as **open polylines** in `section.openPaths` rather than closed contours.
+
+## A whole slicer layer stack
+
+`Mesh.crossSections(axis:through:spacing:)` returns a stack of evenly-spaced sections along an axis —
+a slicer's layer stack. Sections that miss the mesh are skipped:
+
+```swift
+let layers = mesh.crossSections(
+    axis: SIMD3(0, 0, 1),
+    through: SIMD3(0, 0, 0),
+    spacing: 0.2                 // 0.2 mm layers
+)
+
+for (i, layer) in layers.enumerated() {
+    let outerCount = layer.outerContours.count
+    print("layer \(i): \(layer.contours.count) contours (\(outerCount) outer)")
+}
+```
+
+An optional `margin:` insets the first/last slice from each end of the mesh's extent (it defaults to
+`spacing / 2`, so the first and last layers don't sit exactly on an end cap).

--- a/docs/guides/cookbook/decimating-a-mesh.md
+++ b/docs/guides/cookbook/decimating-a-mesh.md
@@ -1,0 +1,75 @@
+---
+title: Decimating a Mesh
+parent: Cookbook
+nav_order: 1
+---
+
+# Decimating a Mesh
+
+`Mesh.simplified(_:)` runs a quadric-error-metric (QEM) edge-collapse decimation pass over the
+mesh and returns a [`SimplifiedMesh`](../../reference/SimplifiedMesh.md) — the reduced mesh plus
+the metadata describing the operation, including the **achieved Hausdorff distance** from input to
+output. It is fallible: it returns `nil` when the options are invalid or the input mesh is empty.
+
+## Reduce to a target triangle count
+
+Pass a [`SimplifyOptions`](../../reference/SimplifyOptions.md) (nested as `Mesh.SimplifyOptions`)
+with `targetTriangleCount` set:
+
+```swift
+import OCCTSwift
+import OCCTSwiftMesh
+
+let mesh: Mesh = shape.mesh()                       // a tessellated Shape from OCCTSwift
+
+guard let result = mesh.simplified(.init(targetTriangleCount: 5_000)) else {
+    // nil → empty input, or invalid options (neither/both targets set, out of range)
+    return
+}
+
+print("\(result.beforeTriangleCount) → \(result.afterTriangleCount) triangles")
+print("Hausdorff error: \(result.hausdorffDistance)")   // absolute, in input mesh units
+let reduced: Mesh = result.mesh
+```
+
+`afterTriangleCount` is a **soft** target: the algorithm may return more triangles than requested
+when topology preservation or the Hausdorff cap stops it early (a tetrahedron can't go below 4
+triangles, for example). Always read `afterTriangleCount` for the actual count and
+`hausdorffDistance` to understand the quality.
+
+## Read and cap the Hausdorff error
+
+`hausdorffDistance` is reported on **every** successful call, whether or not you set a cap. To make
+deviation the controlling constraint, set `maxHausdorffDistance` (absolute, in input units) —
+decimation halts as soon as the measured deviation would exceed it:
+
+```swift
+var options = Mesh.SimplifyOptions(targetReduction: 0.9)   // ask for an aggressive 90% cut...
+options.maxHausdorffDistance = 0.05                        // ...but never deviate more than 0.05
+
+guard let result = mesh.simplified(options) else { return }
+
+if result.hausdorffDistance >= 0.05 {
+    print("Hit the deviation cap at \(result.afterTriangleCount) triangles")
+}
+```
+
+`maxHausdorffDistance` must be `>= 0`; a negative value makes `simplified(_:)` return `nil`.
+
+## Preserve boundary edges
+
+When decimating an open shell — or a mesh you'll later sew back into a B-Rep — keep the free edges
+intact so the boundary doesn't pull inward. `preserveBoundary` defaults to `true`:
+
+```swift
+var options = Mesh.SimplifyOptions(targetReduction: 0.5)
+options.preserveBoundary = true     // free (boundary) edges are not collapsed
+options.preserveTopology = true     // collapses that change genus are rejected (always on today)
+
+guard let result = mesh.simplified(options) else { return }
+```
+
+`preserveTopology` is a forward-compatibility flag — the current backend always preserves topology,
+so setting it to `false` does not (yet) produce more aggressive decimation. See the
+[decimation algorithm notes](../../algorithms/decimation.md) for the full backend semantics,
+vendored meshoptimizer pin, and Hausdorff-unit details.

--- a/docs/guides/cookbook/index.md
+++ b/docs/guides/cookbook/index.md
@@ -1,0 +1,33 @@
+---
+title: Cookbook
+nav_order: 2
+has_children: true
+---
+
+# OCCTSwiftMesh Cookbook
+
+Task-oriented, **example-rich** guides for the OCCTSwiftMesh API — one page per task, each a
+short bit of prose followed by runnable Swift. Every example uses the real shipped API:
+`import OCCTSwiftMesh` (which re-exports `OCCTSwift`'s `Mesh`), and the fallible entry points
+(`simplified(_:)` returns an optional, `crossSection(plane:)` returns an optional) are unwrapped
+with `guard` / `if let` rather than force-unwrapped.
+
+## Conventions
+
+- **Every example is runnable Swift.** Get a `Mesh` from OCCTSwift (`shape.mesh()`) or build one
+  from raw arrays (`Mesh(vertices:indices:)`); the OCCTSwiftMesh entry points are extension methods
+  on that `Mesh`.
+- **Units are the input mesh's vertex units.** Hausdorff distances, cross-section areas, and
+  perimeters all come back in whatever units the input vertices are in (millimetres, typically).
+- **Algorithm deep dives live in [`algorithms/`](../../algorithms/decimation.md).** These recipes
+  show *usage*; the QEM backend, vendored meshoptimizer pin, and Hausdorff-unit semantics are
+  documented there.
+
+## Recipes
+
+- [Decimating a Mesh](decimating-a-mesh.md) — `simplified(_:)` with `SimplifyOptions`, reading
+  the achieved Hausdorff error, capping deviation, and preserving boundary edges.
+- [Target Count vs. Reduction Ratio](target-count-vs-ratio.md) — the two mutually-exclusive
+  targets (`targetTriangleCount` vs. `targetReduction`), overshoot, and when each is the right one.
+- [Cross-Sections & Contours](cross-sections.md) — slice a mesh with a `CutPlane`, read the nested
+  closed `MeshContour`s, distinguish outer walls from holes, and build a whole slicer layer stack.

--- a/docs/guides/cookbook/target-count-vs-ratio.md
+++ b/docs/guides/cookbook/target-count-vs-ratio.md
@@ -1,0 +1,69 @@
+---
+title: Target Count vs. Reduction Ratio
+parent: Cookbook
+nav_order: 2
+---
+
+# Target Count vs. Reduction Ratio
+
+[`SimplifyOptions`](../../reference/SimplifyOptions.md) offers two ways to say *how much* to
+decimate, and they are **mutually exclusive**: exactly one of `targetTriangleCount` or
+`targetReduction` must be set. Passing both — or neither — makes `simplified(_:)` return `nil`.
+
+## `targetTriangleCount` — an absolute count
+
+Use this when you have a concrete budget (a LOD tier, a renderer's per-draw triangle ceiling). The
+count must be in `[1, input.triangleCount]`; outside that range the call returns `nil`.
+
+```swift
+import OCCTSwift
+import OCCTSwiftMesh
+
+guard let result = mesh.simplified(.init(targetTriangleCount: 2_000)) else { return }
+print("Reduced to \(result.afterTriangleCount) triangles")
+```
+
+## `targetReduction` — a fraction to remove
+
+Use this when you want a proportional cut regardless of the input size. It is the **fraction of
+triangles to remove**, in `[0.0, 1.0]`: `0.0` removes nothing, `1.0` decimates as far as the backend
+can. Internally the target count is `round(inputCount × (1 − ratio))`, floored at 1.
+
+```swift
+// Remove 75% of the triangles (keep ~25%)
+guard let result = mesh.simplified(.init(targetReduction: 0.75)) else { return }
+
+let keptFraction = Double(result.afterTriangleCount) / Double(result.beforeTriangleCount)
+print(String(format: "Kept %.0f%%", keptFraction * 100))
+```
+
+## Don't set both
+
+The two targets cannot be combined. This returns `nil`:
+
+```swift
+// ✗ both set → nil
+let bad = mesh.simplified(.init(targetTriangleCount: 2_000, targetReduction: 0.5))
+assert(bad == nil)
+
+// ✗ neither set → nil
+let alsoBad = mesh.simplified(.init())
+assert(alsoBad == nil)
+```
+
+## Overshoot is normal
+
+Neither target is hard. `afterTriangleCount` can exceed the requested count when topology
+preservation or a `maxHausdorffDistance` cap stops the collapse early. Treat the requested target as
+a soft upper bound and check the actual result:
+
+```swift
+guard let result = mesh.simplified(.init(targetTriangleCount: 100)) else { return }
+if result.afterTriangleCount > 100 {
+    print("Stopped at \(result.afterTriangleCount) — couldn't reduce further")
+    print("Deviation so far: \(result.hausdorffDistance)")
+}
+```
+
+See [Decimating a Mesh](decimating-a-mesh.md) for the boundary / Hausdorff options and the
+[algorithm notes](../../algorithms/decimation.md) for why overshoot happens.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,68 @@
+---
+title: Home
+nav_order: 1
+---
+
+# OCCTSwiftMesh documentation
+
+Mesh-domain algorithms for the [OCCTSwift](https://github.com/SecondMouseAU/OCCTSwift) ecosystem.
+OCCTSwiftMesh operates on the `Mesh` triangle-soup value type (declared in `OCCTSwift` and
+re-exported here) and adds the mesh-side post-processing OCCT's open-source distribution
+leaves out: **quadric-error-metric (QEM) decimation** that reports its achieved Hausdorff
+error, and **planar cross-sectioning** that recovers a slice's closed contours the way a
+3D-printer slicer does. Pure-Swift algorithms over `Mesh.vertices` / `Mesh.indices` — no
+extra OCCT kernel calls — so they stay robust on the open, unwelded meshes that raw STL /
+scan bodies actually are.
+
+```swift
+import OCCTSwift
+import OCCTSwiftMesh
+
+let mesh: Mesh = shape.mesh()               // a tessellated Shape from OCCTSwift
+guard let result = mesh.simplified(.init(targetTriangleCount: 5_000)) else { return }
+print("\(result.beforeTriangleCount) → \(result.afterTriangleCount) triangles")
+print("Hausdorff error: \(result.hausdorffDistance)")   // absolute, in input mesh units
+let reduced: Mesh = result.mesh
+```
+
+## Cookbook
+
+Task-oriented, example-rich guides — each a short bit of prose plus runnable Swift. The
+**[Cookbook index](guides/cookbook/)** lists all recipes:
+
+[Decimating a Mesh](guides/cookbook/decimating-a-mesh.md) ·
+[Target Count vs. Reduction Ratio](guides/cookbook/target-count-vs-ratio.md) ·
+[Cross-Sections & Contours](guides/cookbook/cross-sections.md)
+
+## Reference
+
+- **[API Reference](reference/)** — the detailed, per-type reference: signatures, parameters,
+  return values, and runnable examples for every public type.
+- [Decimation algorithm notes](algorithms/decimation.md) — the QEM backend, vendored
+  meshoptimizer, Hausdorff units, and edge-case semantics.
+- [Changelog](CHANGELOG.md) — release-by-release history.
+- [Vendoring](VENDORING.md) — the re-vendoring procedure for the bundled meshoptimizer.
+
+## Project
+
+OCCTSwiftMesh is part of the OCCTSwift family. It depends on `OCCTSwift` for the `Mesh` type
+and vendors [meshoptimizer](https://github.com/zeux/meshoptimizer) (MIT) for the QEM backend.
+Install via Swift Package Manager:
+
+```swift
+// Package.swift
+dependencies: [
+    .package(url: "https://github.com/SecondMouseAU/OCCTSwiftMesh.git", from: "1.1.1"),
+],
+targets: [
+    .target(
+        name: "YourApp",
+        dependencies: [
+            .product(name: "OCCTSwiftMesh", package: "OCCTSwiftMesh"),
+        ]
+    )
+]
+```
+
+- Source & issues: [github.com/SecondMouseAU/OCCTSwiftMesh](https://github.com/SecondMouseAU/OCCTSwiftMesh)
+- Platforms: macOS 12+, iOS 15+. LGPL-2.1, matching OCCTSwift.

--- a/docs/reference/CrossSection.md
+++ b/docs/reference/CrossSection.md
@@ -1,0 +1,330 @@
+---
+title: Cross-Section Types
+parent: API Reference
+---
+
+# Cross-Section Types
+
+Planar slicing of a mesh into closed contours — the perimeter step a 3D-printer slicer performs.
+`CutPlane` describes the cut; `MeshContour` is one classified closed loop; `MeshCrossSection` is the
+whole slice (plane basis + every loop). The entry points are the `Mesh.crossSection(plane:)` and
+`Mesh.crossSections(axis:through:spacing:)` extension methods. Pure geometry over
+`Mesh.vertices` / `Mesh.indices` (no OCCT kernel calls), so it stays robust on open / unwelded scan
+meshes. All three value types are `Sendable`.
+
+## Topics
+
+- [CutPlane](#cutplane) · [CutPlane.init(point:normal:)](#cutplaneinitpointnormal) · [CutPlane.perpendicular(to:offset:)](#cutplaneperpendiculartooffset)
+- [MeshContour](#meshcontour) · [points](#points) · [signedArea](#signedarea) · [depth](#depth) · [parent](#parent) · [isHole](#ishole) · [area](#area) · [perimeter](#perimeter) · [bounds](#bounds)
+- [MeshCrossSection](#meshcrosssection) · [origin / normal / uAxis / vAxis](#origin--normal--uaxis--vaxis) · [contours](#contours) · [openPaths](#openpaths) · [outerContours](#outercontours) · [worldPoint(\_:)](#worldpoint_)
+- [Mesh.crossSection(plane:minLoopArea:weld:)](#meshcrosssectionplaneminloopareaweld) · [Mesh.crossSections(axis:through:spacing:margin:)](#meshcrosssectionsaxisthroughspacingmargin)
+
+---
+
+## CutPlane
+
+An oriented cut plane: a point on the plane and its normal. The normal need not be unit length —
+`Mesh.crossSection` normalizes it.
+
+```swift
+public struct CutPlane: Sendable {
+    public var point: SIMD3<Double>    // a point that lies on the plane
+    public var normal: SIMD3<Double>   // the plane normal (any non-zero length)
+}
+```
+
+---
+
+### `CutPlane.init(point:normal:)`
+
+Creates a cut plane from a point and a (not-necessarily-unit) normal.
+
+```swift
+public init(point: SIMD3<Double>, normal: SIMD3<Double>)
+```
+
+- **Parameters:**
+  - `point` — a point that lies on the plane.
+  - `normal` — the plane normal; any non-zero length (normalized on use).
+- **Example:**
+  ```swift
+  let plane = CutPlane(point: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1))
+  ```
+
+---
+
+### `CutPlane.perpendicular(to:offset:)`
+
+A plane perpendicular to `axis`, positioned `offset` along it from the origin.
+
+```swift
+public static func perpendicular(to axis: SIMD3<Double>, offset: Double) -> CutPlane
+```
+
+- **Parameters:**
+  - `axis` — the direction the plane is perpendicular to (normalized internally).
+  - `offset` — signed distance along the normalized axis from the origin.
+- **Returns:** the `CutPlane`.
+- **Example:**
+  ```swift
+  let z5 = CutPlane.perpendicular(to: SIMD3(0, 0, 1), offset: 5)   // the z = 5 plane
+  ```
+
+---
+
+## MeshContour
+
+One closed loop of a cross-section, expressed in the plane's 2D `(u, v)` basis. Loops are implicitly
+closed (the last point connects back to the first; the first point is not repeated). `depth` /
+`isHole` come from nesting, so they are reliable even on meshes with inconsistent triangle winding.
+
+```swift
+public struct MeshContour: Sendable {
+    public var points: [SIMD2<Double>]
+    public var signedArea: Double
+    public var depth: Int
+    public var parent: Int?
+}
+```
+
+---
+
+### `points`
+
+Ordered loop points in the section plane's `(u, v)` coordinates (millimetres). Implicitly closed.
+
+```swift
+public var points: [SIMD2<Double>]
+```
+
+---
+
+### `signedArea`
+
+Shoelace signed area in plane coordinates (CCW positive). After `crossSection` returns, orientation is
+normalized so an even `depth` (solid boundary) is CCW (`> 0`) and an odd `depth` (hole) is CW (`< 0`).
+
+```swift
+public var signedArea: Double
+```
+
+---
+
+### `depth`
+
+Nesting depth: `0` = outermost solid boundary, `1` = a hole inside it (inner wall / window), `2` = a
+solid island inside that hole, etc.
+
+```swift
+public var depth: Int
+```
+
+---
+
+### `parent`
+
+Index (into the section's `contours`) of the immediately enclosing loop, or `nil` for an outermost
+loop.
+
+```swift
+public var parent: Int?
+```
+
+---
+
+### `isHole`
+
+`true` when this loop bounds empty space inside a solid (odd nesting depth).
+
+```swift
+public var isHole: Bool { get }   // depth % 2 == 1
+```
+
+- **Example:**
+  ```swift
+  for c in section.contours where c.isHole {
+      print("hole of area \(c.area)")
+  }
+  ```
+
+---
+
+### `area`
+
+Unsigned enclosed area.
+
+```swift
+public var area: Double { get }   // abs(signedArea)
+```
+
+---
+
+### `perimeter`
+
+Total perimeter length of the loop (sum of edge lengths, including the implicit closing edge).
+
+```swift
+public var perimeter: Double { get }
+```
+
+---
+
+### `bounds`
+
+Axis-aligned bounds in plane coordinates: `(min, max)`.
+
+```swift
+public var bounds: (min: SIMD2<Double>, max: SIMD2<Double>) { get }
+```
+
+---
+
+## MeshCrossSection
+
+A planar cross-section of a mesh: the plane basis plus every closed loop the plane cuts. Map 2D loop
+points back to 3D with `worldPoint(_:)`.
+
+```swift
+public struct MeshCrossSection: Sendable {
+    public var origin: SIMD3<Double>
+    public var normal: SIMD3<Double>
+    public var uAxis: SIMD3<Double>
+    public var vAxis: SIMD3<Double>
+    public var contours: [MeshContour]
+    public var openPaths: [[SIMD2<Double>]]
+}
+```
+
+---
+
+### `origin` / `normal` / `uAxis` / `vAxis`
+
+The plane basis. `origin` is the `(u, v) = (0, 0)` point in world space; `normal` is the unit plane
+normal; `uAxis` and `vAxis` are the unit in-plane basis vectors (`vAxis = normal × uAxis`).
+
+```swift
+public var origin: SIMD3<Double>
+public var normal: SIMD3<Double>
+public var uAxis: SIMD3<Double>
+public var vAxis: SIMD3<Double>
+```
+
+---
+
+### `contours`
+
+The closed loops cut by the plane, each classified by nesting depth.
+
+```swift
+public var contours: [MeshContour]
+```
+
+---
+
+### `openPaths`
+
+Open polylines (in `(u, v)` coordinates) produced where the plane exits the mesh through a boundary
+edge — e.g. cutting across an open end or a window rim. Empty for a clean section between features.
+
+```swift
+public var openPaths: [[SIMD2<Double>]]
+```
+
+---
+
+### `outerContours`
+
+The outermost loops (nesting depth `0`) — the solid's outer boundary.
+
+```swift
+public var outerContours: [MeshContour] { get }
+```
+
+- **Example:**
+  ```swift
+  print("\(section.outerContours.count) outer wall(s)")
+  ```
+
+---
+
+### `worldPoint(_:)`
+
+Map a plane `(u, v)` coordinate back to a world-space point.
+
+```swift
+public func worldPoint(_ uv: SIMD2<Double>) -> SIMD3<Double>
+```
+
+- **Parameters:**
+  - `uv` — a point in the plane's `(u, v)` basis (e.g. an element of a contour's `points`).
+- **Returns:** the corresponding world-space `SIMD3<Double>`.
+- **Example:**
+  ```swift
+  guard let loop = section.contours.first else { return }
+  let worldRing = loop.points.map { section.worldPoint($0) }
+  ```
+
+---
+
+## Mesh.crossSection(plane:minLoopArea:weld:)
+
+Slice the mesh with a plane and return the closed contours where the plane cuts the surface — a
+3D-printer slicer's perimeter step. Intersection points are welded by quantized world position, so
+the two triangles sharing an edge chain without tolerance fuzz; inner walls and pockets come back as
+separate loops, classified by nesting.
+
+```swift
+func crossSection(plane: CutPlane, minLoopArea: Double = 0, weld: Double = 0) -> MeshCrossSection?
+```
+
+- **Parameters:**
+  - `plane` — the cut plane (normal need not be unit length).
+  - `minLoopArea` — loops with unsigned area below this are discarded as slivers (default `0`, keep
+    everything).
+  - `weld` — spatial tolerance for welding coincident intersection points (handles unwelded STL). `0`
+    (default) auto-derives `1e-6 ×` the mesh's bounding-box diagonal.
+- **Returns:** the [`MeshCrossSection`](#meshcrosssection), or `nil` if the plane misses the mesh
+  entirely.
+- **Example:**
+  ```swift
+  import OCCTSwift
+  import OCCTSwiftMesh
+
+  guard let section = mesh.crossSection(
+      plane: CutPlane(point: SIMD3(0, 0, 5), normal: SIMD3(0, 0, 1)),
+      minLoopArea: 0.01
+  ) else { return }
+
+  for c in section.contours {
+      print("depth \(c.depth)\(c.isHole ? " (hole)" : ""): area \(c.area)")
+  }
+  ```
+
+---
+
+## Mesh.crossSections(axis:through:spacing:margin:)
+
+A stack of evenly-spaced cross-sections along an axis — a slicer's layer stack. Sections that miss the
+mesh are skipped.
+
+```swift
+func crossSections(axis: SIMD3<Double>, through point: SIMD3<Double>,
+                   spacing: Double, margin: Double? = nil) -> [MeshCrossSection]
+```
+
+- **Parameters:**
+  - `axis` — slicing direction (normalized internally).
+  - `point` — a point the axis passes through (the stack is measured from here).
+  - `spacing` — distance between successive section planes. Must be `> 0` (otherwise returns `[]`).
+  - `margin` — inset from each end of the mesh's extent along the axis, so the first/last slice
+    doesn't sit exactly on an end cap (default `spacing / 2`).
+- **Returns:** an array of [`MeshCrossSection`](#meshcrosssection), one per plane that hit the mesh.
+- **Example:**
+  ```swift
+  let layers = mesh.crossSections(
+      axis: SIMD3(0, 0, 1),
+      through: SIMD3(0, 0, 0),
+      spacing: 0.2            // 0.2 mm layers
+  )
+  print("\(layers.count) layers")
+  ```

--- a/docs/reference/Mesh-Simplify.md
+++ b/docs/reference/Mesh-Simplify.md
@@ -1,0 +1,53 @@
+---
+title: Mesh+Simplify
+parent: API Reference
+---
+
+# Mesh+Simplify
+
+The decimation entry point. OCCTSwiftMesh extends `OCCTSwift.Mesh` with `simplified(_:)`, a
+quadric-error-metric (QEM) edge-collapse decimator backed by the vendored
+[meshoptimizer](https://github.com/zeux/meshoptimizer). It takes a
+[`SimplifyOptions`](SimplifyOptions.md) and returns a [`SimplifiedMesh`](SimplifiedMesh.md) — the
+reduced mesh plus the achieved Hausdorff distance — or `nil` on invalid input. See the
+[decimation algorithm notes](../algorithms/decimation.md) for the backend semantics.
+
+## Topics
+
+- [simplified(\_:)](#simplified_)
+
+---
+
+### `simplified(_:)`
+
+Decimate this mesh using a quadric-error-metric edge-collapse algorithm. Orphan vertices left behind
+by collapsed edges are compacted, so the output mesh's `vertexCount` is exactly the count of vertices
+still referenced by a surviving triangle.
+
+```swift
+public func simplified(_ options: Mesh.SimplifyOptions) -> SimplifiedMesh?
+```
+
+- **Parameters:**
+  - `options` — a [`Mesh.SimplifyOptions`](SimplifyOptions.md) carrying the target count *or*
+    reduction ratio (exactly one), plus optional boundary / topology / Hausdorff constraints.
+- **Returns:** a [`SimplifiedMesh`](SimplifiedMesh.md) carrying the decimated mesh and the achieved
+  Hausdorff distance, or `nil` if the options are invalid (neither or both targets set, a
+  `targetTriangleCount` outside `[1, input.triangleCount]`, a `targetReduction` outside `[0, 1]`, or
+  a negative `maxHausdorffDistance`) or the input mesh is empty.
+- **Example:**
+  ```swift
+  import OCCTSwift
+  import OCCTSwiftMesh
+
+  let mesh: Mesh = shape.mesh()
+
+  var options = Mesh.SimplifyOptions(targetReduction: 0.5)
+  options.preserveBoundary = true
+  options.maxHausdorffDistance = 0.05
+
+  guard let result = mesh.simplified(options) else { return }
+  print("\(result.beforeTriangleCount) → \(result.afterTriangleCount) triangles")
+  print("Hausdorff error: \(result.hausdorffDistance)")
+  let reduced: Mesh = result.mesh
+  ```

--- a/docs/reference/OCCTSwiftMesh.md
+++ b/docs/reference/OCCTSwiftMesh.md
@@ -1,0 +1,33 @@
+---
+title: OCCTSwiftMesh
+parent: API Reference
+---
+
+# OCCTSwiftMesh
+
+The module namespace marker. OCCTSwiftMesh's actual public surface lives on **extensions of
+`OCCTSwift.Mesh`** (`simplified(_:)`, `crossSection(plane:)`, `crossSections(...)`) and the value
+types declared alongside each algorithm. This enum exists only to give Xcode something concrete to
+attach the module's documentation to, and to carry the package version.
+
+## Topics
+
+- [version](#version)
+
+---
+
+### `version`
+
+The package version string, bumped on each tagged release.
+
+```swift
+public static let version: String
+```
+
+- **Returns:** the current version string (e.g. `"1.1.0"`).
+- **Example:**
+  ```swift
+  import OCCTSwiftMesh
+
+  print("OCCTSwiftMesh \(OCCTSwiftMesh.version)")
+  ```

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -1,0 +1,29 @@
+---
+title: API Reference
+nav_order: 3
+has_children: true
+---
+
+# OCCTSwiftMesh API Reference
+
+A **detailed, per-type function reference** for the OCCTSwiftMesh Swift API. One page per public
+type, every public symbol documented: signature, behaviour, parameters, return value, and a runnable
+example.
+
+This complements the other docs — it's the *exhaustive* surface, vs:
+- [`guides/cookbook/`](../guides/cookbook/) — *task-oriented* example pages.
+- [`algorithms/decimation.md`](../algorithms/decimation.md) — the QEM backend deep dive.
+
+OCCTSwiftMesh adds its public surface as **extensions on `OCCTSwift.Mesh`** (the triangle-soup value
+type, re-exported via `import OCCTSwiftMesh`) plus the value types each algorithm returns. There is no
+free-standing API beyond the `OCCTSwiftMesh` namespace marker.
+
+## Types
+
+- **[OCCTSwiftMesh](OCCTSwiftMesh.md)** — the module namespace marker (`version` constant).
+- **[Mesh+Simplify](Mesh-Simplify.md)** — the `Mesh.simplified(_:)` decimation entry point.
+- **[SimplifyOptions](SimplifyOptions.md)** — `Mesh.SimplifyOptions`, the decimation inputs.
+- **[SimplifiedMesh](SimplifiedMesh.md)** — the decimation result (mesh + before/after counts +
+  Hausdorff distance).
+- **[Cross-Section Types](CrossSection.md)** — `CutPlane`, `MeshContour`, `MeshCrossSection`, and the
+  `Mesh.crossSection(plane:)` / `Mesh.crossSections(axis:through:spacing:)` slicing entry points.

--- a/docs/reference/SimplifiedMesh.md
+++ b/docs/reference/SimplifiedMesh.md
@@ -1,0 +1,82 @@
+---
+title: SimplifiedMesh
+parent: API Reference
+---
+
+# SimplifiedMesh
+
+The successful result of [`Mesh.simplified(_:)`](Mesh-Simplify.md): the decimated mesh together with
+the metadata describing the operation. A `Sendable` value type. The `hausdorffDistance` is reported on
+every successful call, whether or not a `maxHausdorffDistance` cap was set.
+
+## Topics
+
+- [mesh](#mesh) · [beforeTriangleCount](#beforetrianglecount) · [afterTriangleCount](#aftertrianglecount) · [hausdorffDistance](#hausdorffdistance)
+
+---
+
+### `mesh`
+
+The decimated mesh. Orphan vertices left by collapsed edges are already compacted, so its
+`vertexCount` is exactly the count of vertices referenced by a surviving triangle.
+
+```swift
+public let mesh: Mesh
+```
+
+- **Example:**
+  ```swift
+  guard let result = mesh.simplified(.init(targetReduction: 0.5)) else { return }
+  let reduced: Mesh = result.mesh
+  try reduced.writeSTL(to: outputURL)   // OCCTSwift exporter
+  ```
+
+---
+
+### `beforeTriangleCount`
+
+Triangle count of the input mesh.
+
+```swift
+public let beforeTriangleCount: Int
+```
+
+- **Example:**
+  ```swift
+  print("input had \(result.beforeTriangleCount) triangles")
+  ```
+
+---
+
+### `afterTriangleCount`
+
+Triangle count of the output mesh. May **exceed** the requested target if the algorithm could not
+reduce further while respecting the `maxHausdorffDistance` cap or topology preservation — treat the
+requested target as a soft upper bound.
+
+```swift
+public let afterTriangleCount: Int
+```
+
+- **Example:**
+  ```swift
+  if result.afterTriangleCount > 5_000 {
+      print("overshoot — couldn't reach 5000")
+  }
+  ```
+
+---
+
+### `hausdorffDistance`
+
+The achieved Hausdorff distance from input to output mesh, in input units (absolute). Reported
+regardless of whether `maxHausdorffDistance` was set — read it to understand the decimation quality.
+
+```swift
+public let hausdorffDistance: Double
+```
+
+- **Example:**
+  ```swift
+  print("max surface deviation: \(result.hausdorffDistance) units")
+  ```

--- a/docs/reference/SimplifyOptions.md
+++ b/docs/reference/SimplifyOptions.md
@@ -1,0 +1,134 @@
+---
+title: SimplifyOptions
+parent: API Reference
+---
+
+# SimplifyOptions
+
+Input parameters for [`Mesh.simplified(_:)`](Mesh-Simplify.md). Declared as a nested type,
+`Mesh.SimplifyOptions`, and `Sendable`. **Exactly one** of `targetTriangleCount` or
+`targetReduction` must be set — passing both or neither makes `simplified(_:)` return `nil`.
+
+## Topics
+
+- [init(targetTriangleCount:targetReduction:preserveBoundary:preserveTopology:maxHausdorffDistance:)](#inittargettrianglecounttargetreductionpreserveboundarypreservetopologymaxhausdorffdistance)
+- [targetTriangleCount](#targettrianglecount) · [targetReduction](#targetreduction) · [preserveBoundary](#preserveboundary) · [preserveTopology](#preservetopology) · [maxHausdorffDistance](#maxhausdorffdistance)
+
+---
+
+### `init(targetTriangleCount:targetReduction:preserveBoundary:preserveTopology:maxHausdorffDistance:)`
+
+Creates a `SimplifyOptions`. Set exactly one of `targetTriangleCount` / `targetReduction`; the
+remaining parameters default to boundary- and topology-preserving with no Hausdorff cap.
+
+```swift
+public init(
+    targetTriangleCount: Int? = nil,
+    targetReduction: Double? = nil,
+    preserveBoundary: Bool = true,
+    preserveTopology: Bool = true,
+    maxHausdorffDistance: Double? = nil
+)
+```
+
+- **Parameters:**
+  - `targetTriangleCount` — exact target triangle count; mutually exclusive with `targetReduction`.
+  - `targetReduction` — fraction of triangles to remove in `[0, 1]`; mutually exclusive with
+    `targetTriangleCount`.
+  - `preserveBoundary` — keep free (boundary) edges from collapsing. Default `true`.
+  - `preserveTopology` — reject collapses that change genus. Default `true`.
+  - `maxHausdorffDistance` — optional deviation cap (absolute, input units, `>= 0`).
+- **Example:**
+  ```swift
+  var options = Mesh.SimplifyOptions(targetReduction: 0.5)
+  options.preserveBoundary = true
+  options.maxHausdorffDistance = 0.05
+  let result = mesh.simplified(options)
+  ```
+
+---
+
+### `targetTriangleCount`
+
+Exact target number of triangles in the output mesh. Mutually exclusive with `targetReduction`.
+Must be in `[1, input.triangleCount]`.
+
+```swift
+public var targetTriangleCount: Int?
+```
+
+- **Example:**
+  ```swift
+  let opts = Mesh.SimplifyOptions(targetTriangleCount: 5_000)
+  ```
+
+---
+
+### `targetReduction`
+
+Fraction of input triangles to remove, in `[0.0, 1.0]`. `0.0` = no reduction; `1.0` = decimate as
+far as possible. Mutually exclusive with `targetTriangleCount`. The resolved target count is
+`round(inputCount × (1 − targetReduction))`, floored at 1.
+
+```swift
+public var targetReduction: Double?
+```
+
+- **Example:**
+  ```swift
+  let opts = Mesh.SimplifyOptions(targetReduction: 0.75)   // remove 75%
+  ```
+
+---
+
+### `preserveBoundary`
+
+When `true`, edges on the mesh boundary (free edges) are not collapsed — important when decimating an
+open shell or a mesh that will be sewn back into a B-Rep.
+
+```swift
+public var preserveBoundary: Bool
+```
+
+- **Example:**
+  ```swift
+  var opts = Mesh.SimplifyOptions(targetReduction: 0.5)
+  opts.preserveBoundary = true
+  ```
+
+---
+
+### `preserveTopology`
+
+Forward-compatibility flag. The current backend **always** preserves topology — collapses that would
+change the surface's genus (creating holes, splitting or merging components) are rejected regardless
+of this setting. Setting it to `false` does not (yet) produce more aggressive decimation.
+
+```swift
+public var preserveTopology: Bool
+```
+
+- **Example:**
+  ```swift
+  var opts = Mesh.SimplifyOptions(targetTriangleCount: 1_000)
+  opts.preserveTopology = true   // always honoured today
+  ```
+
+---
+
+### `maxHausdorffDistance`
+
+Optional Hausdorff distance cap. When set, decimation halts as soon as the measured deviation from
+the input mesh would exceed this value, even if the target count has not been reached. Units match
+the input mesh's vertex coordinates (absolute). Must be `>= 0`; a negative value makes
+`simplified(_:)` return `nil`.
+
+```swift
+public var maxHausdorffDistance: Double?
+```
+
+- **Example:**
+  ```swift
+  var opts = Mesh.SimplifyOptions(targetReduction: 0.9)
+  opts.maxHausdorffDistance = 0.05   // never deviate more than 0.05 units
+  ```


### PR DESCRIPTION
Adds an OCCTSwift-style documentation site and a `context7.json` so **OCCTSwiftMesh** is loadable into context7: `docs/index.md`, `docs/guides/` (getting-started + cookbook recipes), `docs/reference/` (per-type API reference), and `context7.json`. Every signature/example copied from the real public API under `Sources/`; GitHub links use SecondMouseAU; code blocks only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)