### PR TITLE
fix(deps): guard sibling-detection against .build/checkouts false-positive

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,12 @@ import Foundation
 // so it's independent of build CWD.
 func occtDep(_ name: String, from version: String) -> Package.Dependency {
     let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+    // Only trust a sibling checkout for a REAL local dev clone — never when this manifest is itself a
+    // transitively-resolved checkout under a consumer's `.build/checkouts/` (SwiftPM lays every dep out
+    // flat there, so `../\(name)` spuriously exists and flips this to a path dep → a SwiftPM identity
+    // conflict with the URL-based dep. See SecondMouseAU/ecosystem#14.
+    if !manifestDir.contains("/.build/"),
+       FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
         return .package(path: "../\(name)")
     }
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", from: Version(version)!)


### PR DESCRIPTION
The `occtDep` helper takes a local `.package(path: "../<name>")` whenever `../<name>/Package.swift` exists. SwiftPM lays every transitive checkout out flat under one `.build/checkouts/`, so when this package is resolved as a dependency, `../<name>` spuriously exists and the dep flips to a path — conflicting with the same package resolved by URL elsewhere, producing SwiftPM `Conflicting identity` warnings that are slated to become hard errors.

Fix: guard the sibling branch with `!manifestDir.contains("/.build/")` so only a real local dev clone uses the path dep. Mirrors SecondMouseAU/OCCTSwiftScripts#70.

Refs SecondMouseAU/ecosystem#14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)