### PR TITLE
Repin OCCTSwift floor to 1.12.3 (thread-safe fillet, #298) — v1.1.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
         // Mesh(vertices:normals:indices:) initializer (OCCTSwift#94) that
         // Mesh.simplified(_:) needs to wrap its raw output. v1.0.x preserves it.
         // Floored at 1.7.1 for OCCT 8.0.0p1 (redesigned BRepGraph/TopologyGraph).
-        occtDep("OCCTSwift", from: "1.7.1"),
+        occtDep("OCCTSwift", from: "1.12.3"),   // ≥1.12.3: thread-safe 3D fillet/chamfer (#298, kernel patch 0003)
     ],
     targets: [
         // Public Swift API: Mesh.simplified(_:) and friends.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to OCCTSwiftMesh.
 
+## v1.1.3 — repin OCCTSwift 1.12.3 (thread-safe fillet)
+
+Repin the OCCTSwift floor to **1.12.3**, which carries OCCT kernel patch 0003 making 3D fillet/chamfer reentrant across threads ([OCCTSwift#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298) / upstream [OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)). Ecosystem-wide floor bump; no API or behaviour change.
+
 ## v1.1.0 — `Mesh.crossSection(plane:)` planar slicing
 
 Adds a mesh **slicer**: intersect a mesh with a plane and recover the closed


### PR DESCRIPTION
Bumps the OCCTSwift floor to **1.12.3** (kernel patch 0003 — thread-safe 3D fillet/chamfer, [#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298) / upstream [OCCT#1374](https://github.com/Open-Cascade-SAS/OCCT/pull/1374)). Ecosystem-wide repin. Manifest-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)