### PR TITLE
Mesh foundations + region segmentation — v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OCCTSwift itself stays focused on its mission as an OCCT wrapper. Mesh algorithm
 
 ## Status
 
-✅ **v1.1.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1) and `Mesh.crossSection(plane:)` (planar slicing into closed contours). Requires OCCTSwift v1.0.1 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
+✅ **v1.2.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), and `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
 
 ## API
 
@@ -63,6 +63,44 @@ for c in section!.contours {
 
 // Or a whole slicer layer stack along an axis:
 let stack = mesh.crossSections(axis: axis, through: p, spacing: 2.0)
+```
+
+### Mesh foundations — weld, connectivity, integrity
+
+Raw OCCT tessellation and STL import both produce (near-)unshared vertices — three unique
+positions per triangle even where triangles are geometrically edge-adjacent. `welded(tolerance:)`
+merges coincident vertices; every adjacency-based operation below needs that welded substrate to
+see real connectivity.
+
+```swift
+let welded = mesh.welded()                 // 0 auto-derives 1e-6 × the bbox diagonal
+
+welded.faceNormals()                       // [SIMD3<Float>], one per triangle
+welded.vertexNormals()                     // area-weighted, per vertex
+welded.triangleAdjacency()                 // [[Int]] — edge-adjacent triangles
+welded.connectedComponents()               // [MeshRegion], largest-first
+welded.subMesh(triangleIndices: [0, 1])    // extract a compact standalone Mesh
+welded.boundaryLoops()                     // [[UInt32]] — open-edge rings
+
+let report = mesh.integrityReport()        // welds internally — safe to call on raw input
+print(report.isWatertight, report.nonManifoldEdgeCount, report.boundaryLoopCount)
+print(report.eulerCharacteristic, report.genus as Any)
+```
+
+### Segmentation — `Mesh.segmented(_:)`
+
+Dihedral region-growing splits a mesh into smoothly-connected surface patches, then a
+primitive-fit merge pass undoes coarse-tessellation "confetti" (a low-poly cylinder's facets,
+each past the dihedral threshold, growing back into one cylinder + end caps). Welds internally,
+so unwelded input doesn't silently degrade to one region per triangle.
+
+```swift
+let segmented = mesh.segmented()           // Mesh.SegmentOptions() defaults
+for (region, fit) in zip(segmented.regions, segmented.fits) {
+    print(region.triangleIndices.count, "triangles →", fit.kind, fit.residualRMS)
+}
+// segmented.truncatedTriangleCount reports anything dropped by maxRegions / minRegionTriangles —
+// never silent.
 ```
 
 ## Installation

--- a/Sources/OCCTSwiftMesh/FittedPrimitive.swift
+++ b/Sources/OCCTSwiftMesh/FittedPrimitive.swift
@@ -1,0 +1,44 @@
+// FittedPrimitive.swift — the surface a segmented region best fits, with its measured
+// deviation from the source triangles.
+
+/// A primitive surface fitted to a mesh region.
+public struct FittedPrimitive: Sendable, Equatable {
+    public enum Kind: String, Sendable, Equatable {
+        case plane, cylinder, sphere, cone
+    }
+
+    public let kind: Kind
+
+    /// - `plane`:    `[nx, ny, nz, d]` (`n·x = d`, `|n| = 1`)
+    /// - `sphere`:   `[cx, cy, cz, r]`
+    /// - `cylinder`: `[px, py, pz, ax, ay, az, r]` (point on axis, unit axis direction, radius)
+    /// - `cone`:     `[apexX, apexY, apexZ, ax, ay, az, halfAngle]` (apex, unit axis direction,
+    ///   half-angle in radians)
+    public let params: [Double]
+
+    public let residualRMS: Double
+    public let residualMax: Double
+    /// Fraction of the region's vertices within `max(2 · residualRMS, 1e-4)` of the surface.
+    public let inlierRatio: Double
+
+    public init(kind: Kind, params: [Double], residualRMS: Double, residualMax: Double, inlierRatio: Double) {
+        self.kind = kind
+        self.params = params
+        self.residualRMS = residualRMS
+        self.residualMax = residualMax
+        self.inlierRatio = inlierRatio
+    }
+
+    public var radius: Double? {
+        switch kind {
+        case .sphere: return params.count >= 4 ? params[3] : nil
+        case .cylinder: return params.count >= 7 ? params[6] : nil
+        case .plane, .cone: return nil
+        }
+    }
+
+    /// Half-angle in degrees, for cones.
+    public var coneHalfAngleDegrees: Double? {
+        kind == .cone && params.count >= 7 ? params[6] * 180 / .pi : nil
+    }
+}

--- a/Sources/OCCTSwiftMesh/Linalg.swift
+++ b/Sources/OCCTSwiftMesh/Linalg.swift
@@ -1,0 +1,92 @@
+// Linalg.swift — small dense linear algebra used by primitive fitting.
+//
+// Fitting runs in Double for stability even though mesh data is Float. Internal to the
+// package — PrimitiveFitter is the only consumer.
+
+import Foundation
+import simd
+
+enum Linalg {
+
+    /// Eigen-decomposition of a symmetric 3×3 matrix via cyclic Jacobi rotations.
+    /// Returns eigenvalues ascending, with `vectors[k]` the unit eigenvector for `values[k]`.
+    static func eigenSymmetric3(_ input: [[Double]]) -> (values: [Double], vectors: [[Double]]) {
+        var a = input
+        var v: [[Double]] = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        let pairs = [(0, 1), (0, 2), (1, 2)]
+
+        for _ in 0..<60 {
+            var (p, q) = (0, 1)
+            var off = abs(a[0][1])
+            for (i, j) in pairs where abs(a[i][j]) > off { off = abs(a[i][j]); p = i; q = j }
+            if off < 1e-15 { break }
+
+            let phi = 0.5 * atan2(2 * a[p][q], a[q][q] - a[p][p])
+            let c = cos(phi), s = sin(phi)
+
+            for k in 0..<3 {
+                let akp = a[k][p], akq = a[k][q]
+                a[k][p] = c * akp - s * akq
+                a[k][q] = s * akp + c * akq
+            }
+            for k in 0..<3 {
+                let apk = a[p][k], aqk = a[q][k]
+                a[p][k] = c * apk - s * aqk
+                a[q][k] = s * apk + c * aqk
+            }
+            for k in 0..<3 {
+                let vkp = v[k][p], vkq = v[k][q]
+                v[k][p] = c * vkp - s * vkq
+                v[k][q] = s * vkp + c * vkq
+            }
+        }
+
+        var triples = (0..<3).map { (a[$0][$0], [v[0][$0], v[1][$0], v[2][$0]]) }
+        triples.sort { $0.0 < $1.0 }
+        return (triples.map { $0.0 }, triples.map { normalize3($0.1) })
+    }
+
+    /// Covariance (scatter) matrix of points about their centroid, as a 3×3 symmetric matrix.
+    static func covariance(_ points: [SIMD3<Double>]) -> (matrix: [[Double]], centroid: SIMD3<Double>) {
+        guard !points.isEmpty else { return ([[0, 0, 0], [0, 0, 0], [0, 0, 0]], .zero) }
+        var c = SIMD3<Double>.zero
+        for p in points { c += p }
+        c /= Double(points.count)
+        var m = [[0.0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        for p in points {
+            let d = p - c
+            m[0][0] += d.x * d.x; m[0][1] += d.x * d.y; m[0][2] += d.x * d.z
+            m[1][1] += d.y * d.y; m[1][2] += d.y * d.z; m[2][2] += d.z * d.z
+        }
+        m[1][0] = m[0][1]; m[2][0] = m[0][2]; m[2][1] = m[1][2]
+        return (m, c)
+    }
+
+    /// Solve a small linear system `Ax = b` by Gaussian elimination with partial pivoting.
+    /// Returns nil if singular.
+    static func solve(_ A: [[Double]], _ b: [Double]) -> [Double]? {
+        let n = b.count
+        var m = A.map { $0 }
+        var x = b
+        for col in 0..<n {
+            var pivot = col
+            for r in (col + 1)..<n where abs(m[r][col]) > abs(m[pivot][col]) { pivot = r }
+            if abs(m[pivot][col]) < 1e-15 { return nil }
+            m.swapAt(col, pivot); x.swapAt(col, pivot)
+            let inv = 1.0 / m[col][col]
+            for r in 0..<n where r != col {
+                let f = m[r][col] * inv
+                if f == 0 { continue }
+                for k in col..<n { m[r][k] -= f * m[col][k] }
+                x[r] -= f * x[col]
+            }
+        }
+        for i in 0..<n { x[i] /= m[i][i] }
+        return x
+    }
+
+    static func normalize3(_ v: [Double]) -> [Double] {
+        let len = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).squareRoot()
+        return len > 1e-300 ? [v[0] / len, v[1] / len, v[2] / len] : [0, 0, 1]
+    }
+}

--- a/Sources/OCCTSwiftMesh/Mesh+Segmentation.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Segmentation.swift
@@ -78,9 +78,13 @@ extension Mesh {
     }
 
     /// Deterministic DFS flood over edge-adjacent triangles, absorbing an unassigned neighbour
-    /// iff its face normal is within `maxDihedralDegrees` of the seed triangle's. Region
-    /// membership is a pure reachability computation over a fixed (order-independent) adjacency
-    /// SET, so it doesn't depend on `adjacency[t]`'s internal element order — only on seed order
+    /// iff its face normal is within `maxDihedralDegrees` of the CURRENT triangle's (a local
+    /// flood, matching the reference implementation) — only adjacent-pair steps are gated, never
+    /// neighbour-vs-seed, so a region tolerates gradual curvature drift well beyond the
+    /// threshold across its extent. Because the pairwise gate is symmetric, region membership is
+    /// exactly the connected component of the "smooth-edge" subgraph (adjacency pairs whose
+    /// normals agree within the threshold) containing the seed: a pure reachability computation
+    /// that doesn't depend on `adjacency[t]`'s internal element order — only on seed order
     /// (`0..<triangleCount`, deterministic).
     static func segmentSmoothRegions(triangleCount tc: Int, normals: [SIMD3<Float>], adjacency: [[Int]],
                                      maxDihedralDegrees: Float) -> [[Int]] {

--- a/Sources/OCCTSwiftMesh/Mesh+Segmentation.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Segmentation.swift
@@ -1,0 +1,252 @@
+// Mesh+Segmentation.swift — dihedral region-growing + primitive-fit merge.
+//
+// Region-growing alone shatters a coarsely-tessellated curved surface: a low-poly cylinder's
+// facets sit >maxDihedralDegrees apart, so each becomes its own planar region ("confetti").
+// The merge pass is the mandatory companion — it greedily unions adjacent regions whose union
+// still fits ONE primitive within tolerance, collapsing those facets back into one cylinder,
+// while leaving real edges (where the union fits nothing well) intact.
+//
+// Ported from OCCTReconstruct's ReconstructCompute (RegionSegmentation.swift +
+// RegionMerging.swift), adapted to operate on OCCTSwift.Mesh's own arrays instead of a
+// separate IndexedMesh type, and to weld internally (see below) rather than assume a
+// pre-welded input.
+
+import Foundation
+import simd
+import OCCTSwift
+
+extension Mesh {
+
+    /// Segment into smoothly-connected surface regions (dihedral region-growing), then merge
+    /// adjacent regions whose union still fits a single primitive — undoing coarse-tessellation
+    /// "confetti."
+    ///
+    /// Welds internally (`options.weldTolerance`) so unwelded input (raw OCCT tessellation,
+    /// STL import) does not silently degrade to one region per triangle: adjacency always
+    /// reflects the welded topology, but every `MeshRegion.triangleIndices` refers to THIS
+    /// mesh's own (possibly unwelded) triangle order — welding only affects which triangles
+    /// are considered neighbours, never the triangle indexing callers see.
+    public func segmented(_ options: SegmentOptions = .init()) -> SegmentedMesh {
+        let verts = vertices
+        let idx = indices
+        let tc = triangleCount
+        guard tc > 0, !verts.isEmpty else { return SegmentedMesh(regions: [], fits: [], truncatedTriangleCount: 0) }
+
+        var lo = verts[0], hi = verts[0]
+        for p in verts { lo = simd_min(lo, p); hi = simd_max(hi, p) }
+        let bodyDiag = Double(simd_length(hi - lo))
+
+        // Weld for topology only — geometric fitting below uses the ORIGINAL vertices/indices.
+        let (remap, weldedPositions) = Mesh.weldPositions(verts, tolerance: options.weldTolerance)
+        var weldedIndices = [UInt32](repeating: 0, count: idx.count)
+        for i in idx.indices { weldedIndices[i] = remap[Int(idx[i])] }
+
+        let normals = Mesh.faceNormals(vertices: weldedPositions, indices: weldedIndices, triangleCount: tc)
+        let adjacency = Mesh.triangleAdjacency(indices: weldedIndices, triangleCount: tc)
+
+        let seeds = Mesh.segmentSmoothRegions(triangleCount: tc, normals: normals, adjacency: adjacency,
+                                              maxDihedralDegrees: options.maxDihedralDegrees)
+            .map { MeshRegion(triangleIndices: $0, area: Mesh.area(ofTriangles: $0, vertices: verts, indices: idx)) }
+            .sorted(by: MeshRegion.order)
+
+        let (mergedRegions, fits) = RegionMerging.merge(
+            vertices: verts, indices: idx, regions: seeds, faceNormals: normals, adjacency: adjacency,
+            bodyDiag: bodyDiag, relativeTolerance: options.mergeRelativeTolerance,
+            maxMergeAngleDegrees: options.maxMergeAngleDegrees)
+
+        var filteredRegions: [MeshRegion] = []
+        var filteredFits: [FittedPrimitive] = []
+        var dropped = 0
+        for (region, fit) in zip(mergedRegions, fits) {
+            if region.triangleIndices.count < options.minRegionTriangles {
+                dropped += region.triangleIndices.count
+            } else {
+                filteredRegions.append(region)
+                filteredFits.append(fit)
+            }
+        }
+        if let rawCap = options.maxRegions {
+            let cap = max(rawCap, 0)   // a non-positive cap safely means "keep none", never a crash
+            if filteredRegions.count > cap {
+                for region in filteredRegions[cap...] { dropped += region.triangleIndices.count }
+                filteredRegions = Array(filteredRegions[..<cap])
+                filteredFits = Array(filteredFits[..<cap])
+            }
+        }
+
+        return SegmentedMesh(regions: filteredRegions, fits: filteredFits, truncatedTriangleCount: dropped)
+    }
+
+    /// Deterministic DFS flood over edge-adjacent triangles, absorbing an unassigned neighbour
+    /// iff its face normal is within `maxDihedralDegrees` of the seed triangle's. Region
+    /// membership is a pure reachability computation over a fixed (order-independent) adjacency
+    /// SET, so it doesn't depend on `adjacency[t]`'s internal element order — only on seed order
+    /// (`0..<triangleCount`, deterministic).
+    static func segmentSmoothRegions(triangleCount tc: Int, normals: [SIMD3<Float>], adjacency: [[Int]],
+                                     maxDihedralDegrees: Float) -> [[Int]] {
+        guard tc > 0 else { return [] }
+        let cosThreshold = cos(maxDihedralDegrees * .pi / 180)
+
+        var region = [Int](repeating: -1, count: tc)
+        var regions: [[Int]] = []
+        for seed in 0..<tc where region[seed] == -1 {
+            let id = regions.count
+            var members: [Int] = []
+            var stack = [seed]
+            region[seed] = id
+            while let t = stack.popLast() {
+                members.append(t)
+                let nt = normals[t]
+                for n in adjacency[t] where region[n] == -1 {
+                    if simd_dot(nt, normals[n]) >= cosThreshold {
+                        region[n] = id
+                        stack.append(n)
+                    }
+                }
+            }
+            regions.append(members)
+        }
+        return regions
+    }
+}
+
+/// Agglomerative region merging that repairs coarse-tessellation shattering.
+enum RegionMerging {
+
+    /// Merge regions by primitive fit. Returns the merged regions (largest-first) and each
+    /// merged region's best fit.
+    static func merge(vertices: [SIMD3<Float>], indices: [UInt32], regions inputRegions: [MeshRegion],
+                      faceNormals: [SIMD3<Float>], adjacency: [[Int]], bodyDiag: Double,
+                      relativeTolerance: Double, maxMergeAngleDegrees: Float,
+                      maxRegionsToMerge: Int = 1500) -> (regions: [MeshRegion], fits: [FittedPrimitive]) {
+        var regions = inputRegions
+        // Cheap coplanar pre-merge keeps the fit-gated pass below usable at 400k+ triangle
+        // scans, where raw region counts can run into the thousands: a tight (~2°) coplanar
+        // threshold only ever collapses genuinely-flat confetti, never a real curved seam.
+        if regions.count > maxRegionsToMerge {
+            regions = coplanarPreMerge(vertices: vertices, indices: indices, regions: regions,
+                                       faceNormals: faceNormals, adjacency: adjacency)
+        }
+
+        let n = regions.count
+        guard n > 1, n <= maxRegionsToMerge else {
+            let fits = regions.map {
+                PrimitiveFitter.bestFit(vertices: vertices, indices: indices, region: $0,
+                                       faceNormals: faceNormals, bodyDiag: bodyDiag)
+            }
+            return (regions, fits)
+        }
+
+        let mergeTol = max(relativeTolerance * bodyDiag, 1e-6)
+
+        var regionOf = [Int](repeating: -1, count: indices.count / 3)
+        for (rid, region) in regions.enumerated() { for t in region.triangleIndices { regionOf[t] = rid } }
+
+        // Region adjacency, tracking the SOFTEST→HARDEST boundary: per pair keep the sharpest
+        // dihedral (min dot) across shared facet edges. A pair is mergeable only if even its
+        // sharpest shared edge is "soft" (below maxMergeAngle).
+        let cosMergeAngle = cos(maxMergeAngleDegrees * .pi / 180)
+        func packPair(_ a: Int, _ b: Int) -> UInt64 { (UInt64(min(a, b)) << 32) | UInt64(max(a, b)) }
+        var pairMinDot = [UInt64: Float]()
+        for t in 0..<(indices.count / 3) {
+            let ra = regionOf[t]
+            for nb in adjacency[t] where regionOf[nb] != ra {
+                let key = packPair(ra, regionOf[nb])
+                let d = simd_dot(faceNormals[t], faceNormals[nb])
+                pairMinDot[key] = min(pairMinDot[key] ?? 1, d)
+            }
+        }
+        // Soft-boundary pairs only, processed SMOOTHEST first (highest minDot) so each surface
+        // consolidates before sharper cross-feature boundaries are evaluated. DETERMINISM:
+        // sort by minDot desc, tie-break on the packed pair key — otherwise equal-dihedral
+        // pairs would order arbitrarily (dictionary iteration), making the union-find process
+        // them in a different order each run → different region compositions.
+        let pairList = pairMinDot
+            .filter { $0.value >= cosMergeAngle }
+            .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
+            .map { (Int($0.key >> 32), Int($0.key & 0xFFFF_FFFF)) }
+
+        // The degrade guard: a merge is allowed only if the union still fits a single primitive
+        // about as well as the better of the two parts.
+        let slack = 0.5 * mergeTol
+
+        var parent = Array(0..<n)
+        var members = regions.map { $0.triangleIndices }
+        var rootFit = regions.map {
+            PrimitiveFitter.bestFit(vertices: vertices, indices: indices, region: $0,
+                                   faceNormals: faceNormals, bodyDiag: bodyDiag)
+        }
+        func find(_ x: Int) -> Int { var r = x; while parent[r] != r { parent[r] = parent[parent[r]]; r = parent[r] }; return r }
+
+        var changed = true
+        var passes = 0
+        while changed, passes < 60 {
+            changed = false; passes += 1
+            for (ra, rb) in pairList {
+                let a = find(ra), b = find(rb)
+                if a == b { continue }
+                let union = members[a] + members[b]
+                let unionArea = Mesh.area(ofTriangles: union, vertices: vertices, indices: indices)
+                let fit = PrimitiveFitter.bestFit(vertices: vertices, indices: indices,
+                                                 region: MeshRegion(triangleIndices: union, area: unionArea),
+                                                 faceNormals: faceNormals, bodyDiag: bodyDiag)
+                let separateBest = min(rootFit[a].residualRMS, rootFit[b].residualRMS)
+                guard fit.residualRMS <= mergeTol, fit.residualRMS <= separateBest + slack else { continue }
+                parent[b] = a
+                members[a] = union
+                members[b] = []
+                rootFit[a] = fit
+                changed = true
+            }
+        }
+
+        var pairs: [(MeshRegion, FittedPrimitive)] = []
+        for r in 0..<n where find(r) == r && !members[r].isEmpty {
+            let area = Mesh.area(ofTriangles: members[r], vertices: vertices, indices: indices)
+            pairs.append((MeshRegion(triangleIndices: members[r], area: area), rootFit[r]))
+        }
+        pairs.sort { MeshRegion.order($0.0, $1.0) }
+        return (pairs.map { $0.0 }, pairs.map { $0.1 })
+    }
+
+    /// Cheap, fit-free pre-pass: union-find adjacent regions whose shared boundary is nearly
+    /// coplanar (within ~2°), unconditionally. A single pass suffices — union-find correctly
+    /// merges transitive chains regardless of the order pairs are processed in, since every
+    /// pair above threshold merges unconditionally (unlike the fit-gated pass, whose merges are
+    /// conditional on a per-step primitive-fit test and so need iterative re-evaluation).
+    static func coplanarPreMerge(vertices: [SIMD3<Float>], indices: [UInt32], regions: [MeshRegion],
+                                 faceNormals: [SIMD3<Float>], adjacency: [[Int]]) -> [MeshRegion] {
+        let n = regions.count
+        var regionOf = [Int](repeating: -1, count: indices.count / 3)
+        for (rid, r) in regions.enumerated() { for t in r.triangleIndices { regionOf[t] = rid } }
+
+        let cosCoplanar = cos(2.0 * .pi / 180)
+        func packPair(_ a: Int, _ b: Int) -> UInt64 { (UInt64(min(a, b)) << 32) | UInt64(max(a, b)) }
+        var pairMinDot = [UInt64: Float]()
+        for t in 0..<(indices.count / 3) {
+            let ra = regionOf[t]
+            for nb in adjacency[t] where regionOf[nb] != ra {
+                let key = packPair(ra, regionOf[nb])
+                let d = simd_dot(faceNormals[t], faceNormals[nb])
+                pairMinDot[key] = min(pairMinDot[key] ?? 1, d)
+            }
+        }
+        let pairList = pairMinDot
+            .filter { Double($0.value) >= cosCoplanar }
+            .sorted { $0.value != $1.value ? $0.value > $1.value : $0.key < $1.key }
+            .map { (Int($0.key >> 32), Int($0.key & 0xFFFF_FFFF)) }
+
+        var parent = Array(0..<n)
+        func find(_ x: Int) -> Int { var r = x; while parent[r] != r { parent[r] = parent[parent[r]]; r = parent[r] }; return r }
+        for (a, b) in pairList {
+            let ra = find(a), rb = find(b)
+            if ra != rb { parent[rb] = ra }
+        }
+
+        var buckets: [Int: [Int]] = [:]
+        for (i, r) in regions.enumerated() { buckets[find(i), default: []].append(contentsOf: r.triangleIndices) }
+        return buckets.values
+            .map { tris in MeshRegion(triangleIndices: tris.sorted(), area: Mesh.area(ofTriangles: tris, vertices: vertices, indices: indices)) }
+            .sorted(by: MeshRegion.order)
+    }
+}

--- a/Sources/OCCTSwiftMesh/Mesh+Topology.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Topology.swift
@@ -1,0 +1,220 @@
+// Mesh+Topology.swift — the connectivity toolkit: face/vertex normals, triangle adjacency,
+// connected components, sub-mesh extraction, and boundary loops.
+//
+// `triangleAdjacency()`, `connectedComponents()`, and `boundaryLoops()` all key their
+// connectivity off shared VERTEX INDICES — they need a welded mesh (see `welded(tolerance:)`)
+// to see real adjacency. On unwelded input (per-triangle-unique vertices, the common case for
+// raw OCCT tessellation / STL import) no two triangles share an index, so each comes back
+// isolated: every triangle its own component, every edge a "boundary." Weld first.
+
+import simd
+import OCCTSwift
+
+extension Mesh {
+
+    /// Unit face normals, one per triangle (a degenerate triangle gets a +Z fallback).
+    /// Independent of welding — computed directly from each triangle's own three corners.
+    public func faceNormals() -> [SIMD3<Float>] {
+        Mesh.faceNormals(vertices: vertices, indices: indices, triangleCount: triangleCount)
+    }
+
+    static func faceNormals(vertices: [SIMD3<Float>], indices: [UInt32], triangleCount: Int) -> [SIMD3<Float>] {
+        var out: [SIMD3<Float>] = []
+        out.reserveCapacity(triangleCount)
+        for t in 0..<triangleCount {
+            let base = t * 3
+            let a = vertices[Int(indices[base])]
+            let b = vertices[Int(indices[base + 1])]
+            let c = vertices[Int(indices[base + 2])]
+            let n = simd_cross(b - a, c - a)
+            let len = simd_length(n)
+            out.append(len > 1e-12 ? n / len : SIMD3<Float>(0, 0, 1))
+        }
+        return out
+    }
+
+    /// Area-weighted per-vertex normals, summed from adjacent triangles' face normals.
+    ///
+    /// Meaningful smoothing requires a WELDED mesh (call `.welded()` first) — on unwelded
+    /// input each vertex touches exactly one triangle, so the result is just that triangle's
+    /// flat face normal repeated per corner. Independent of `Mesh.normals`, which may come
+    /// from the source B-Rep face tessellation rather than this mesh's own topology.
+    public func vertexNormals() -> [SIMD3<Float>] {
+        let verts = vertices
+        let idx = indices
+        var normals = [SIMD3<Float>](repeating: .zero, count: verts.count)
+        var tri = 0
+        while tri + 2 < idx.count {
+            let ia = idx[tri], ib = idx[tri + 1], ic = idx[tri + 2]
+            tri += 3
+            let a = verts[Int(ia)], b = verts[Int(ib)], c = verts[Int(ic)]
+            let faceNormal = simd_cross(b - a, c - a)   // magnitude = 2·area (area weighting)
+            normals[Int(ia)] += faceNormal
+            normals[Int(ib)] += faceNormal
+            normals[Int(ic)] += faceNormal
+        }
+        for i in normals.indices {
+            let len = simd_length(normals[i])
+            normals[i] = len > 1e-12 ? normals[i] / len : SIMD3<Float>(0, 0, 1)
+        }
+        return normals
+    }
+
+    /// Per-triangle adjacency: the indices of triangles sharing a WELDED edge with each
+    /// triangle, each sorted ascending. Requires `.welded()` first — see the file header.
+    public func triangleAdjacency() -> [[Int]] {
+        Mesh.triangleAdjacency(indices: indices, triangleCount: triangleCount)
+    }
+
+    static func triangleAdjacency(indices: [UInt32], triangleCount: Int) -> [[Int]] {
+        var edgeMap: [UInt64: [Int]] = [:]
+        func key(_ a: UInt32, _ b: UInt32) -> UInt64 {
+            let lo = UInt64(min(a, b)), hi = UInt64(max(a, b))
+            return (hi << 32) | lo
+        }
+        for t in 0..<triangleCount {
+            let base = t * 3
+            let a = indices[base], b = indices[base + 1], c = indices[base + 2]
+            for e in [key(a, b), key(b, c), key(c, a)] { edgeMap[e, default: []].append(t) }
+        }
+        var adjacency = [[Int]](repeating: [], count: triangleCount)
+        for (_, tris) in edgeMap where tris.count > 1 {
+            for i in 0..<tris.count {
+                for j in (i + 1)..<tris.count {
+                    adjacency[tris[i]].append(tris[j])
+                    adjacency[tris[j]].append(tris[i])
+                }
+            }
+        }
+        // DETERMINISM: edgeMap is a Dictionary, whose iteration order Swift randomizes per
+        // process (a fresh hash seed each run) — without this sort, a triangle's neighbour
+        // list comes back in a different ORDER each run (same set, different order), which
+        // leaks into segmentSmoothRegions' DFS visit order and makes MeshRegion.triangleIndices
+        // non-reproducible between runs on identical input.
+        for i in adjacency.indices { adjacency[i].sort() }
+        return adjacency
+    }
+
+    /// Split into connected components (physically disjoint pieces) by union-find over shared
+    /// WELDED vertex indices. Requires `.welded()` first — see the file header. Components are
+    /// returned largest-first (`MeshRegion`'s deterministic ordering).
+    public func connectedComponents() -> [MeshRegion] {
+        let tc = triangleCount
+        guard tc > 0 else { return [] }
+        let idx = indices
+        let verts = vertices
+
+        var parent = Array(0..<verts.count)
+        func find(_ x: Int) -> Int {
+            var r = x
+            while parent[r] != r { r = parent[r] }
+            var c = x
+            while parent[c] != c { let next = parent[c]; parent[c] = r; c = next }
+            return r
+        }
+        func union(_ a: Int, _ b: Int) {
+            let ra = find(a), rb = find(b)
+            if ra != rb { parent[ra] = rb }
+        }
+        for t in 0..<tc {
+            let base = t * 3
+            union(Int(idx[base]), Int(idx[base + 1]))
+            union(Int(idx[base + 1]), Int(idx[base + 2]))
+        }
+
+        var buckets: [Int: [Int]] = [:]
+        for t in 0..<tc {
+            buckets[find(Int(idx[t * 3])), default: []].append(t)
+        }
+        return buckets.values
+            .map { tris in MeshRegion(triangleIndices: tris, area: Mesh.area(ofTriangles: tris, vertices: verts, indices: idx)) }
+            .sorted(by: MeshRegion.order)
+    }
+
+    /// Extract a subset of triangles as a standalone mesh, with vertices remapped to a
+    /// compact range — used to isolate a region or component for separate processing.
+    ///
+    /// - Returns: the extracted mesh, or `nil` if `triangleIndices` is empty or every index
+    ///   is out of range.
+    public func subMesh(triangleIndices: [Int]) -> Mesh? {
+        let verts = vertices
+        let idx = indices
+        let tc = triangleCount
+        var remap: [UInt32: UInt32] = [:]
+        var newPositions: [SIMD3<Float>] = []
+        var newIndices: [UInt32] = []
+        newIndices.reserveCapacity(triangleIndices.count * 3)
+
+        for t in triangleIndices {
+            guard t >= 0, t < tc else { continue }
+            let base = t * 3
+            for g in [idx[base], idx[base + 1], idx[base + 2]] {
+                let local: UInt32
+                if let m = remap[g] {
+                    local = m
+                } else {
+                    local = UInt32(newPositions.count)
+                    remap[g] = local
+                    newPositions.append(verts[Int(g)])
+                }
+                newIndices.append(local)
+            }
+        }
+        return Mesh(vertices: newPositions, indices: newIndices)
+    }
+
+    /// Ordered boundary loops (vertex-index rings) of the open edges — edges used by exactly
+    /// one triangle. Requires `.welded()` first — see the file header; on unwelded input
+    /// every edge is used by exactly one triangle, so every triangle's three edges come back
+    /// as their own 3-edge "loop" instead of the mesh's real open boundary.
+    public func boundaryLoops() -> [[UInt32]] {
+        let idx = indices
+        let tc = triangleCount
+        func ekey(_ a: UInt32, _ b: UInt32) -> UInt64 {
+            let lo = UInt64(min(a, b)), hi = UInt64(max(a, b))
+            return (hi << 32) | lo
+        }
+        var edgeCount: [UInt64: Int] = [:]
+        for t in 0..<tc {
+            let base = t * 3
+            let a = idx[base], b = idx[base + 1], c = idx[base + 2]
+            for e in [ekey(a, b), ekey(b, c), ekey(c, a)] { edgeCount[e, default: 0] += 1 }
+        }
+        let boundary = edgeCount.filter { $0.value == 1 }.keys
+        guard !boundary.isEmpty else { return [] }
+
+        var remaining = Set<UInt64>(boundary)
+        var nbr: [UInt32: [UInt32]] = [:]
+        for e in boundary {
+            let a = UInt32(e >> 32), b = UInt32(e & 0xffff_ffff)
+            nbr[a, default: []].append(b)
+            nbr[b, default: []].append(a)
+        }
+        // DETERMINISM: seed loops in sorted edge order and pick neighbours in sorted order.
+        // Set/dict iteration order varies run-to-run, so without this a different seed chains
+        // edges into different loops at non-manifold junctions — making the result
+        // non-reproducible between runs.
+        for k in Array(nbr.keys) { nbr[k]?.sort() }
+        let seeds = boundary.sorted()
+
+        var loops: [[UInt32]] = []
+        for seed in seeds where remaining.contains(seed) {
+            let sa = UInt32(seed >> 32), sb = UInt32(seed & 0xffff_ffff)
+            remaining.remove(seed)
+            var loop: [UInt32] = [sa, sb]
+            var prev = sa, cur = sb
+            while cur != sa {
+                let opts = (nbr[cur] ?? []).filter { $0 != prev && remaining.contains(ekey(cur, $0)) }
+                guard let nx = opts.first ?? (nbr[cur] ?? []).first(where: { remaining.contains(ekey(cur, $0)) }) else { break }
+                remaining.remove(ekey(cur, nx))
+                if nx == sa { break }
+                loop.append(nx)
+                prev = cur
+                cur = nx
+                if loop.count > boundary.count + 2 { break }
+            }
+            if loop.count >= 3 { loops.append(loop) }
+        }
+        return loops
+    }
+}

--- a/Sources/OCCTSwiftMesh/Mesh+Welding.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Welding.swift
@@ -1,0 +1,84 @@
+// Mesh+Welding.swift — merge coincident vertices so adjacency-based algorithms have a
+// shared substrate to work on.
+//
+// OCCT tessellation and STL loading both produce (near-)unshared vertices in practice: three
+// unique positions per triangle, even where triangles are geometrically edge-adjacent. Every
+// adjacency-based primitive in this package (triangleAdjacency, connectedComponents,
+// boundaryLoops, segmented) needs a WELDED mesh to see that adjacency at all — on unwelded
+// input, no two triangles share a vertex index, so each looks isolated. Weld first.
+
+import simd
+import OCCTSwift
+
+extension Mesh {
+    /// Snap each vertex to a spatial grid cell and merge every vertex landing in the same
+    /// cell, keeping the first-encountered position as that cell's representative. Returns
+    /// the per-original-vertex remap (into the deduplicated `positions`) alongside the
+    /// deduplicated positions themselves. Internal building block shared by `welded(tolerance:)`
+    /// and every algorithm that needs welded topology without discarding the caller's own
+    /// triangle indexing (weld positions, keep indices/order intact).
+    static func weldPositions(_ vertices: [SIMD3<Float>], tolerance: Double) -> (remap: [UInt32], positions: [SIMD3<Float>]) {
+        guard !vertices.isEmpty else { return ([], []) }
+        var lo = vertices[0], hi = vertices[0]
+        for p in vertices { lo = simd_min(lo, p); hi = simd_max(hi, p) }
+        let diag = Double(simd_length(hi - lo))
+        // Same auto-derivation as crossSection's weld default: tiny relative to the model,
+        // far below any real wall thickness, so distinct points stay distinct.
+        let cell = tolerance > 0 ? tolerance : max(1e-9, 1e-6 * diag)
+
+        struct GridKey: Hashable { var x: Int64; var y: Int64; var z: Int64 }
+        // Clamped so a huge coordinate over a tiny cell (e.g. every vertex coincident, so
+        // `diag == 0` and `cell` floors to `1e-9`, combined with coordinates of order 1e10+)
+        // can't overflow the Double → Int64 conversion and trap. Values only ever meet at this
+        // boundary for coordinate magnitudes many orders beyond any plausible model — safe.
+        func gridCoord(_ x: Float, _ cell: Double) -> Int64 {
+            let d = (Double(x) / cell).rounded()
+            guard d.isFinite else { return 0 }
+            return Int64(max(-9.0e18, min(9.0e18, d)))
+        }
+        var cellToIndex: [GridKey: UInt32] = [:]
+        var remap = [UInt32](repeating: 0, count: vertices.count)
+        var positions: [SIMD3<Float>] = []
+        positions.reserveCapacity(vertices.count)
+        for i in vertices.indices {
+            let p = vertices[i]
+            let key = GridKey(x: gridCoord(p.x, cell), y: gridCoord(p.y, cell), z: gridCoord(p.z, cell))
+            if let existing = cellToIndex[key] {
+                remap[i] = existing
+            } else {
+                let newIndex = UInt32(positions.count)
+                cellToIndex[key] = newIndex
+                positions.append(p)
+                remap[i] = newIndex
+            }
+        }
+        return (remap, positions)
+    }
+
+    /// Merge coincident vertices within `tolerance`, remapping every triangle to its shared
+    /// vertex and dropping any triangle that degenerates (repeats a vertex) as a result.
+    ///
+    /// - Parameter tolerance: spatial merge radius. `0` (default) auto-derives
+    ///   `1e-6 ×` the mesh's bounding-box diagonal, matching `crossSection`'s weld default.
+    /// - Returns: the welded mesh, or `self` unchanged if it has no vertices/triangles, or if
+    ///   welding collapsed every triangle to degenerate (a pathological all-coincident input).
+    public func welded(tolerance: Double = 0) -> Mesh {
+        let verts = vertices
+        let idx = indices
+        guard !verts.isEmpty, idx.count >= 3 else { return self }
+
+        let (remap, positions) = Mesh.weldPositions(verts, tolerance: tolerance)
+
+        var newIndices: [UInt32] = []
+        newIndices.reserveCapacity(idx.count)
+        var tri = 0
+        while tri + 2 < idx.count {
+            let a = remap[Int(idx[tri])], b = remap[Int(idx[tri + 1])], c = remap[Int(idx[tri + 2])]
+            tri += 3
+            guard a != b, b != c, a != c else { continue }
+            newIndices.append(a); newIndices.append(b); newIndices.append(c)
+        }
+        guard let out = Mesh(vertices: positions, indices: newIndices) else { return self }
+        return out
+    }
+}

--- a/Sources/OCCTSwiftMesh/MeshIntegrityReport.swift
+++ b/Sources/OCCTSwiftMesh/MeshIntegrityReport.swift
@@ -1,0 +1,248 @@
+// MeshIntegrityReport.swift — a holistic manifoldness / validity / quality snapshot.
+//
+// Semantics follow the Open3D `TriangleMesh` conventions (is_edge_manifold /
+// is_vertex_manifold / is_watertight / cluster_connected_triangles), which are the cleanest
+// in the field. Welds internally so the report is meaningful on raw, per-triangle-unique OCCT
+// tessellation or STL import without the caller needing to weld first — but duplicate and
+// degenerate triangles are counted BEFORE they're cleaned up (that's the point of the report),
+// while every other metric (manifoldness, Euler characteristic, genus, components, sliver
+// signals) is computed on the deduplicated, non-degenerate topology so a handful of exact
+// duplicate faces don't masquerade as a real non-manifold defect.
+
+import Foundation
+import simd
+import OCCTSwift
+
+/// A mesh's manifoldness, validity, and quality snapshot.
+public struct MeshIntegrityReport: Sendable {
+    /// Every welded edge is shared by exactly two triangles (no boundary, no non-manifold edges).
+    public let isWatertight: Bool
+    /// Every 2-triangle welded edge is traversed in opposite directions by its two triangles —
+    /// a consistent winding exists. Only evaluated over 2-triangle edges; not meaningful when
+    /// `nonManifoldEdgeCount > 0`.
+    public let isOrientable: Bool
+    /// Welded edges shared by three or more triangles.
+    public let nonManifoldEdgeCount: Int
+    /// Vertices whose surrounding triangles don't form a single fan (a "pinch point" / bowtie,
+    /// or a branching link).
+    public let nonManifoldVertexCount: Int
+    /// Count of open boundary loops (see `boundaryLoops()`).
+    public let boundaryLoopCount: Int
+    /// Triangles that repeat an earlier triangle's vertex set (any winding), counted from the
+    /// raw welded topology before cleanup.
+    public let duplicateTriangleCount: Int
+    /// Triangles that repeat a vertex post-weld (a welded edge collapsed to a point), counted
+    /// from the raw welded topology before cleanup.
+    public let degenerateTriangleCount: Int
+    /// `V - E + F` of the deduplicated, non-degenerate, welded topology.
+    public let eulerCharacteristic: Int
+    /// Total genus across all closed components, or `nil` unless `isWatertight && isOrientable`
+    /// (and the Euler characteristic is consistent with a valid closed 2-manifold).
+    public let genus: Int?
+    /// Connected components (see `connectedComponents()`), largest-first.
+    public let components: [(triangleCount: Int, area: Double)]
+    /// Smallest interior angle across all triangles, in degrees: the absolute worst case and
+    /// the 5th percentile (a sliver signal more robust to one degenerate outlier).
+    public let minAngleDegrees: (min: Double, p05: Double)
+    /// Equilateral-normalized aspect ratio (`longestEdge / (2·√3·inradius)`, the VTK/FEM
+    /// convention where an equilateral triangle scores `1.0`): worst case and 95th percentile.
+    public let aspectRatio: (max: Double, p95: Double)
+}
+
+extension Mesh {
+    /// Compute a manifoldness / validity / quality snapshot of this mesh.
+    ///
+    /// - Parameter weldTolerance: forwarded to the internal weld pass. `0` (default)
+    ///   auto-derives `1e-6 ×` the mesh's bounding-box diagonal.
+    public func integrityReport(weldTolerance: Double = 0) -> MeshIntegrityReport {
+        let empty = MeshIntegrityReport(
+            isWatertight: false, isOrientable: true, nonManifoldEdgeCount: 0,
+            nonManifoldVertexCount: 0, boundaryLoopCount: 0, duplicateTriangleCount: 0,
+            degenerateTriangleCount: 0, eulerCharacteristic: 0, genus: nil, components: [],
+            minAngleDegrees: (0, 0), aspectRatio: (0, 0))
+
+        let verts0 = vertices
+        let idx0 = indices
+        guard !verts0.isEmpty, idx0.count >= 3 else { return empty }
+
+        let (remap, weldedPositions) = Mesh.weldPositions(verts0, tolerance: weldTolerance)
+        let tc0 = idx0.count / 3
+
+        var degenerateCount = 0
+        var duplicateCount = 0
+        var seenFaces = Set<UInt64>()
+        var cleanIndices: [UInt32] = []
+        cleanIndices.reserveCapacity(idx0.count)
+        for t in 0..<tc0 {
+            let base = t * 3
+            let a = remap[Int(idx0[base])], b = remap[Int(idx0[base + 1])], c = remap[Int(idx0[base + 2])]
+            if a == b || b == c || a == c { degenerateCount += 1; continue }
+            let s = [a, b, c].sorted()
+            let key = (UInt64(s[0]) << 42) ^ (UInt64(s[1]) << 21) ^ UInt64(s[2])
+            if !seenFaces.insert(key).inserted { duplicateCount += 1; continue }
+            cleanIndices.append(a); cleanIndices.append(b); cleanIndices.append(c)
+        }
+
+        guard !cleanIndices.isEmpty, let clean = Mesh(vertices: weldedPositions, indices: cleanIndices) else {
+            return MeshIntegrityReport(
+                isWatertight: false, isOrientable: true, nonManifoldEdgeCount: 0,
+                nonManifoldVertexCount: 0, boundaryLoopCount: 0, duplicateTriangleCount: duplicateCount,
+                degenerateTriangleCount: degenerateCount, eulerCharacteristic: 0, genus: nil,
+                components: [], minAngleDegrees: (0, 0), aspectRatio: (0, 0))
+        }
+
+        let cIdx = clean.indices
+        let cVerts = clean.vertices
+        let tc = clean.triangleCount
+
+        func ekey(_ a: UInt32, _ b: UInt32) -> UInt64 {
+            let lo = UInt64(min(a, b)), hi = UInt64(max(a, b))
+            return (hi << 32) | lo
+        }
+        var edgeCount: [UInt64: Int] = [:]
+        var edgeDir: [UInt64: (fwd: Int, bwd: Int)] = [:]
+        for t in 0..<tc {
+            let base = t * 3
+            let tri = [cIdx[base], cIdx[base + 1], cIdx[base + 2]]
+            for k in 0..<3 {
+                let a = tri[k], b = tri[(k + 1) % 3]
+                let key = ekey(a, b)
+                edgeCount[key, default: 0] += 1
+                var d = edgeDir[key] ?? (0, 0)
+                if a < b { d.fwd += 1 } else { d.bwd += 1 }
+                edgeDir[key] = d
+            }
+        }
+        let nonManifoldEdgeCount = edgeCount.values.filter { $0 >= 3 }.count
+        let boundaryEdgeCount = edgeCount.values.filter { $0 == 1 }.count
+        let isWatertight = boundaryEdgeCount == 0 && nonManifoldEdgeCount == 0
+
+        var isOrientable = true
+        for (key, cnt) in edgeCount where cnt == 2 {
+            let d = edgeDir[key] ?? (0, 0)
+            if d.fwd != 1 || d.bwd != 1 { isOrientable = false; break }
+        }
+
+        let nonManifoldVertexCount = Mesh.countNonManifoldVertices(indices: cIdx)
+        let boundaryLoopCount = clean.boundaryLoops().count
+        let components = clean.connectedComponents().map { (triangleCount: $0.triangleIndices.count, area: $0.area) }
+
+        // V is the count of vertices actually REFERENCED by a clean triangle, not
+        // `cVerts.count` — `weldedPositions` holds every welded vertex from the whole input,
+        // computed before degenerate/duplicate triangles are dropped, so a vertex used only by
+        // a dropped triangle would otherwise survive as an uncounted orphan and inflate V (and
+        // so corrupt the Euler characteristic / genus, which only OCCTSwift.Mesh's initializer
+        // — never trimming unreferenced vertices — lets through).
+        let V = Set(cIdx).count
+        let E = edgeCount.count
+        let F = tc
+        let euler = V - E + F
+        var genus: Int? = nil
+        if isWatertight, isOrientable {
+            let c = max(components.count, 1)
+            let numerator = 2 * c - euler
+            if numerator >= 0, numerator % 2 == 0 { genus = numerator / 2 }
+        }
+
+        let (minAngle, aspect) = Mesh.angleAndAspectStats(vertices: cVerts, indices: cIdx, triangleCount: tc)
+
+        return MeshIntegrityReport(
+            isWatertight: isWatertight, isOrientable: isOrientable,
+            nonManifoldEdgeCount: nonManifoldEdgeCount, nonManifoldVertexCount: nonManifoldVertexCount,
+            boundaryLoopCount: boundaryLoopCount, duplicateTriangleCount: duplicateCount,
+            degenerateTriangleCount: degenerateCount, eulerCharacteristic: euler, genus: genus,
+            components: components, minAngleDegrees: minAngle, aspectRatio: aspect)
+    }
+
+    /// A vertex is non-manifold if the triangles around it don't form a single fan. For each
+    /// triangle containing `v`, the edge OPPOSITE `v` is one link of `v`'s "umbrella"; in a
+    /// manifold those opposite edges chain into a single simple path (open) or cycle (closed).
+    /// A branch point (an opposite-edge endpoint touched by 3+ opposite edges) or a second
+    /// disconnected chain (a pinch point / bowtie) makes `v` non-manifold.
+    static func countNonManifoldVertices(indices: [UInt32]) -> Int {
+        var oppositeEdges: [UInt32: [(UInt32, UInt32)]] = [:]
+        let tc = indices.count / 3
+        for t in 0..<tc {
+            let base = t * 3
+            let tri = [indices[base], indices[base + 1], indices[base + 2]]
+            for k in 0..<3 {
+                let v = tri[k]
+                let b = tri[(k + 1) % 3], c = tri[(k + 2) % 3]
+                oppositeEdges[v, default: []].append((b, c))
+            }
+        }
+        var count = 0
+        for (_, edges) in oppositeEdges {
+            guard edges.count > 1 else { continue }
+            var adj: [UInt32: Set<UInt32>] = [:]
+            for (b, c) in edges {
+                adj[b, default: []].insert(c)
+                adj[c, default: []].insert(b)
+            }
+            if adj.values.contains(where: { $0.count > 2 }) { count += 1; continue }
+            var visited = Set<UInt32>()
+            var components = 0
+            for start in adj.keys where !visited.contains(start) {
+                components += 1
+                var stack = [start]
+                visited.insert(start)
+                while let n = stack.popLast() {
+                    for nb in adj[n] ?? [] where !visited.contains(nb) {
+                        visited.insert(nb)
+                        stack.append(nb)
+                    }
+                }
+            }
+            if components > 1 { count += 1 }
+        }
+        return count
+    }
+
+    /// Per-triangle minimum interior angle (degrees) and equilateral-normalized aspect ratio
+    /// distributions, reduced to (min, p05) and (max, p95) respectively.
+    static func angleAndAspectStats(vertices: [SIMD3<Float>], indices: [UInt32], triangleCount: Int)
+        -> (minAngle: (min: Double, p05: Double), aspect: (max: Double, p95: Double)) {
+        guard triangleCount > 0 else { return ((0, 0), (0, 0)) }
+
+        func angleAt(_ p: SIMD3<Double>, _ q: SIMD3<Double>, _ r: SIMD3<Double>) -> Double {
+            let u = simd_normalize(q - p), v = simd_normalize(r - p)
+            let d = max(-1.0, min(1.0, simd_dot(u, v)))
+            return acos(d) * 180 / .pi
+        }
+        func percentile(_ xs: [Double], _ p: Double) -> Double {
+            let sorted = xs.sorted()
+            let i = min(sorted.count - 1, max(0, Int((p * Double(sorted.count - 1)).rounded())))
+            return sorted[i]
+        }
+
+        var perTriMinAngle: [Double] = []
+        var perTriAspect: [Double] = []
+        perTriMinAngle.reserveCapacity(triangleCount)
+        perTriAspect.reserveCapacity(triangleCount)
+
+        for t in 0..<triangleCount {
+            let base = t * 3
+            let a = SIMD3<Double>(vertices[Int(indices[base])])
+            let b = SIMD3<Double>(vertices[Int(indices[base + 1])])
+            let c = SIMD3<Double>(vertices[Int(indices[base + 2])])
+            let ab = simd_length(b - a), bc = simd_length(c - b), ca = simd_length(a - c)
+            guard ab > 1e-12, bc > 1e-12, ca > 1e-12 else { continue }
+
+            perTriMinAngle.append(min(angleAt(a, b, c), angleAt(b, c, a), angleAt(c, a, b)))
+
+            let longest = max(ab, bc, ca)
+            let area = simd_length(simd_cross(b - a, c - a)) * 0.5
+            let semiperimeter = (ab + bc + ca) / 2
+            guard semiperimeter > 1e-12 else { continue }
+            let inradius = area / semiperimeter
+            guard inradius > 1e-12 else { continue }
+            perTriAspect.append(longest / (2 * 3.0.squareRoot() * inradius))
+        }
+
+        guard !perTriMinAngle.isEmpty, !perTriAspect.isEmpty else { return ((0, 0), (0, 0)) }
+        return (
+            (perTriMinAngle.min() ?? 0, percentile(perTriMinAngle, 0.05)),
+            (perTriAspect.max() ?? 0, percentile(perTriAspect, 0.95))
+        )
+    }
+}

--- a/Sources/OCCTSwiftMesh/MeshRegion.swift
+++ b/Sources/OCCTSwiftMesh/MeshRegion.swift
@@ -1,0 +1,46 @@
+// MeshRegion — a named subset of a mesh's triangles.
+//
+// The common currency between connected-component splitting (Mesh.connectedComponents())
+// and surface segmentation (Mesh.segmented(_:)): both hand back regions as triangle-index
+// groups, largest-first, with a precomputed geometric area.
+
+import simd
+import OCCTSwift
+
+/// A subset of a mesh's triangles, e.g. one connected component or one segmented surface patch.
+public struct MeshRegion: Sendable, Equatable {
+    /// Indices into the owning mesh's triangle list (`indices[i*3 ..< i*3+3]` per `i` here).
+    public let triangleIndices: [Int]
+    /// Total geometric area of the region's triangles, in the owning mesh's units.
+    public let area: Double
+
+    public init(triangleIndices: [Int], area: Double) {
+        self.triangleIndices = triangleIndices
+        self.area = area
+    }
+
+    /// Deterministic ordering used everywhere regions are returned: more triangles first,
+    /// ties broken by lowest triangle index. Without the tie-break, equal-sized regions
+    /// built from unordered Dictionary/Set buckets would shuffle order between runs.
+    static func order(_ a: MeshRegion, _ b: MeshRegion) -> Bool {
+        if a.triangleIndices.count != b.triangleIndices.count {
+            return a.triangleIndices.count > b.triangleIndices.count
+        }
+        return (a.triangleIndices.min() ?? 0) < (b.triangleIndices.min() ?? 0)
+    }
+}
+
+extension Mesh {
+    /// Sum of triangle areas for a set of triangle indices into `indices`/`vertices`.
+    static func area(ofTriangles triangleIndices: [Int], vertices: [SIMD3<Float>], indices: [UInt32]) -> Double {
+        var sum = 0.0
+        for t in triangleIndices {
+            let base = t * 3
+            let a = vertices[Int(indices[base])]
+            let b = vertices[Int(indices[base + 1])]
+            let c = vertices[Int(indices[base + 2])]
+            sum += Double(simd_length(simd_cross(b - a, c - a)) * 0.5)
+        }
+        return sum
+    }
+}

--- a/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
+++ b/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
@@ -3,6 +3,11 @@
 // Mesh.simplified(_:) — QEM decimation via vendored meshoptimizer.
 // Mesh.crossSection(plane:) — planar slicing into closed contours (a 3D-printer
 //   slicer's perimeter step); robust on open / unwelded scan meshes.
+// Mesh.welded(tolerance:), .faceNormals(), .vertexNormals(), .triangleAdjacency(),
+//   .connectedComponents(), .subMesh(triangleIndices:), .boundaryLoops(),
+//   .integrityReport() — the mesh connectivity toolkit and quality/validity snapshot.
+// Mesh.segmented(_:) — dihedral region-growing + primitive-fit merge, splitting a mesh
+//   into plane/cylinder/sphere/cone surface regions.
 // See docs/CHANGELOG.md and docs/algorithms/.
 
 /// Namespace marker for the OCCTSwiftMesh module. The public surface lives
@@ -11,5 +16,5 @@
 /// to attach the module's documentation to.
 public enum OCCTSwiftMesh {
     /// Package version. Bump on each tagged release.
-    public static let version = "1.1.0"
+    public static let version = "1.2.0"
 }

--- a/Sources/OCCTSwiftMesh/PrimitiveFitter.swift
+++ b/Sources/OCCTSwiftMesh/PrimitiveFitter.swift
@@ -1,0 +1,223 @@
+// PrimitiveFitter.swift — fits plane / sphere / cylinder / cone candidates to a region's
+// points and picks the best, with a simplicity bias. Internal engine behind
+// `Mesh.segmented(_:)`; ported from OCCTReconstruct's ReconstructCompute.PrimitiveFitting.
+
+import Foundation
+import simd
+import OCCTSwift
+
+enum PrimitiveFitter {
+
+    /// Fit the best primitive (lowest residual, with a simplicity bias toward planes) to a
+    /// region. `vertices`/`indices` should be the mesh's ORIGINAL (unwelded) arrays — fitting
+    /// wants the truest available geometry, unperturbed by weld snapping. `bodyDiag` is the
+    /// whole mesh's bounding-box diagonal, precomputed once by the caller (fitting runs once
+    /// per candidate merge, so rescanning bounds per call would be quadratic at scale).
+    static func bestFit(vertices: [SIMD3<Float>], indices: [UInt32], region: MeshRegion,
+                        faceNormals: [SIMD3<Float>], bodyDiag: Double) -> FittedPrimitive {
+        let pts = regionPoints(vertices: vertices, indices: indices, region: region)
+        let normals = region.triangleIndices.map { SIMD3<Double>(faceNormals[$0]) }
+
+        var candidates: [FittedPrimitive] = []
+        if let plane = fitPlane(points: pts) { candidates.append(plane) }
+        if let sphere = fitSphere(points: pts) { candidates.append(sphere) }
+        if let cyl = fitCylinder(points: pts, normals: normals) { candidates.append(cyl) }
+        if let cone = fitCone(points: pts, normals: normals) { candidates.append(cone) }
+
+        // A cone with a tiny half-angle IS a cylinder the cone fit stole: its extra DOF absorbs
+        // scan noise so it always scores >= the cylinder, and the preference tie-break only
+        // fires within 1.25x. Drop near-cylindrical cones whenever a cylinder candidate exists.
+        if let coneIdx = candidates.firstIndex(where: { $0.kind == .cone }),
+           let half = candidates[coneIdx].coneHalfAngleDegrees, abs(half) < 2.5,
+           candidates.contains(where: { $0.kind == .cylinder }) {
+            candidates.remove(at: coneIdx)
+        }
+
+        guard let bestRMS = candidates.map(\.residualRMS).min() else {
+            return FittedPrimitive(kind: .plane, params: [0, 0, 1, 0],
+                                   residualRMS: .infinity, residualMax: .infinity, inlierRatio: 0)
+        }
+        // Among fits about as good as the best residual, prefer the simpler / more-common
+        // primitive (plane > cylinder > cone > sphere) — this breaks ambiguous ties (e.g. a
+        // short band a sphere also fits perfectly is really a cylinder). The absolute floor
+        // matters: when the best fit is near-zero, a near-perfect cone must still count as
+        // "acceptable" against an exact sphere.
+        let absFloor = 1e-3 * bodyDiag
+        let preference: [FittedPrimitive.Kind: Int] = [.plane: 0, .cylinder: 1, .cone: 2, .sphere: 3]
+        let acceptable = candidates.filter { $0.residualRMS <= bestRMS * 1.25 + absFloor }
+        return acceptable.min { (preference[$0.kind] ?? 9) < (preference[$1.kind] ?? 9) }!
+    }
+
+    // MARK: Plane
+
+    static func fitPlane(points pts: [SIMD3<Double>]) -> FittedPrimitive? {
+        guard pts.count >= 3 else { return nil }
+        let (cov, centroid) = Linalg.covariance(pts)
+        let (_, vectors) = Linalg.eigenSymmetric3(cov)
+        let n = SIMD3<Double>(vectors[0][0], vectors[0][1], vectors[0][2])   // smallest-variance dir
+        let d = simd_dot(n, centroid)
+        let residuals = pts.map { abs(simd_dot(n, $0) - d) }
+        let (rms, mx, inl) = stats(residuals)
+        return FittedPrimitive(kind: .plane, params: [n.x, n.y, n.z, d],
+                               residualRMS: rms, residualMax: mx, inlierRatio: inl)
+    }
+
+    // MARK: Sphere (algebraic / Kåsa)
+
+    static func fitSphere(points pts: [SIMD3<Double>]) -> FittedPrimitive? {
+        guard pts.count >= 4 else { return nil }
+        // Solve [2x,2y,2z,1]·[cx,cy,cz,k] = x²+y²+z², then r² = k + |c|².
+        var ata = [[Double]](repeating: [0, 0, 0, 0], count: 4)
+        var atb = [Double](repeating: 0, count: 4)
+        for p in pts {
+            let row = [2 * p.x, 2 * p.y, 2 * p.z, 1.0]
+            let rhs = p.x * p.x + p.y * p.y + p.z * p.z
+            for i in 0..<4 {
+                atb[i] += row[i] * rhs
+                for j in 0..<4 { ata[i][j] += row[i] * row[j] }
+            }
+        }
+        guard let sol = Linalg.solve(ata, atb) else { return nil }
+        let c = SIMD3<Double>(sol[0], sol[1], sol[2])
+        let r2 = sol[3] + simd_dot(c, c)
+        guard r2 > 0 else { return nil }
+        let r = r2.squareRoot()
+        let residuals = pts.map { abs(simd_length($0 - c) - r) }
+        let (rms, mx, inl) = stats(residuals)
+        return FittedPrimitive(kind: .sphere, params: [c.x, c.y, c.z, r],
+                               residualRMS: rms, residualMax: mx, inlierRatio: inl)
+    }
+
+    // MARK: Cylinder
+
+    static func fitCylinder(points pts: [SIMD3<Double>], normals: [SIMD3<Double>]) -> FittedPrimitive? {
+        guard pts.count >= 6, !normals.isEmpty else { return nil }
+        // Axis = direction the surface normals avoid = smallest eigenvector of Σ nnᵀ.
+        var s = [[0.0, 0, 0], [0, 0, 0], [0, 0, 0]]
+        for n in normals {
+            s[0][0] += n.x * n.x; s[0][1] += n.x * n.y; s[0][2] += n.x * n.z
+            s[1][1] += n.y * n.y; s[1][2] += n.y * n.z; s[2][2] += n.z * n.z
+        }
+        s[1][0] = s[0][1]; s[2][0] = s[0][2]; s[2][1] = s[1][2]
+        let (_, evecs) = Linalg.eigenSymmetric3(s)
+        let axis = simd_normalize(SIMD3<Double>(evecs[0][0], evecs[0][1], evecs[0][2]))
+
+        let helper = abs(axis.x) < 0.9 ? SIMD3<Double>(1, 0, 0) : SIMD3<Double>(0, 1, 0)
+        let u = simd_normalize(simd_cross(axis, helper))
+        let v = simd_cross(axis, u)
+
+        var origin = SIMD3<Double>.zero
+        for p in pts { origin += p }
+        origin /= Double(pts.count)
+
+        // Fit a circle in (u, v): [2pu, 2pv, 1]·[a, b, k] = pu²+pv², r² = k + a²+b².
+        var ata = [[Double]](repeating: [0, 0, 0], count: 3)
+        var atb = [Double](repeating: 0, count: 3)
+        var proj: [(Double, Double)] = []
+        proj.reserveCapacity(pts.count)
+        for p in pts {
+            let rel = p - origin
+            let pu = simd_dot(rel, u), pv = simd_dot(rel, v)
+            proj.append((pu, pv))
+            let row = [2 * pu, 2 * pv, 1.0]
+            let rhs = pu * pu + pv * pv
+            for i in 0..<3 {
+                atb[i] += row[i] * rhs
+                for j in 0..<3 { ata[i][j] += row[i] * row[j] }
+            }
+        }
+        guard let sol = Linalg.solve(ata, atb) else { return nil }
+        let (a, b) = (sol[0], sol[1])
+        let r2 = sol[2] + a * a + b * b
+        guard r2 > 0 else { return nil }
+        let r = r2.squareRoot()
+        let center3d = origin + a * u + b * v
+
+        let residuals = proj.map { abs((($0.0 - a) * ($0.0 - a) + ($0.1 - b) * ($0.1 - b)).squareRoot() - r) }
+        let (rms, mx, inl) = stats(residuals)
+        return FittedPrimitive(kind: .cylinder,
+                               params: [center3d.x, center3d.y, center3d.z, axis.x, axis.y, axis.z, r],
+                               residualRMS: rms, residualMax: mx, inlierRatio: inl)
+    }
+
+    // MARK: Cone
+
+    static func fitCone(points pts: [SIMD3<Double>], normals: [SIMD3<Double>]) -> FittedPrimitive? {
+        guard pts.count >= 6, normals.count >= 3 else { return nil }
+
+        // On a cone, every surface normal makes a constant angle with the axis: n·a = -sin(α).
+        // So the unit normals lie in a plane whose normal is the axis a. Fit that plane: a is
+        // the least-variance direction of the (centered) normals; sin(α) = |mean(n·a)|.
+        let (cov, meanNormal) = Linalg.covariance(normals)
+        let (_, evecs) = Linalg.eigenSymmetric3(cov)
+        var axis = simd_normalize(SIMD3<Double>(evecs[0][0], evecs[0][1], evecs[0][2]))
+        let sinAlpha = abs(simd_dot(meanNormal, axis))
+        guard sinAlpha > 0.0871, sinAlpha < 0.9962 else { return nil }   // α ∈ (~5°, ~85°)
+        let alpha = asin(min(max(sinAlpha, 0), 1))
+        let cosAlpha = cos(alpha)
+
+        var c0 = SIMD3<Double>.zero
+        for p in pts { c0 += p }
+        c0 /= Double(pts.count)
+
+        func axialRadial(_ axis: SIMD3<Double>) -> (A: [Double], R: [Double]) {
+            var A = [Double](), R = [Double]()
+            A.reserveCapacity(pts.count); R.reserveCapacity(pts.count)
+            for p in pts {
+                let rel = p - c0
+                let a = simd_dot(rel, axis)
+                let radial = simd_length(rel - a * axis)
+                A.append(a); R.append(radial)
+            }
+            return (A, R)
+        }
+
+        var (axialA, radialR) = axialRadial(axis)
+        // Orient the axis so radius grows away from the apex (positive covariance of A and R).
+        let meanA = axialA.reduce(0, +) / Double(pts.count)
+        let meanR = radialR.reduce(0, +) / Double(pts.count)
+        var covAR = 0.0
+        for i in 0..<pts.count { covAR += (axialA[i] - meanA) * (radialR[i] - meanR) }
+        if covAR < 0 { axis = -axis; (axialA, radialR) = axialRadial(axis) }
+
+        // Apex q = c0 + s·a. Perpendicular deviation d_i = R_i cosα − A_i sinα + s sinα; solve s.
+        var meanE = 0.0
+        for i in 0..<pts.count { meanE += radialR[i] * cosAlpha - axialA[i] * sinAlpha }
+        meanE /= Double(pts.count)
+        let s = -meanE / sinAlpha
+        let apex = c0 + s * axis
+
+        let residuals = (0..<pts.count).map {
+            abs(radialR[$0] * cosAlpha - axialA[$0] * sinAlpha + s * sinAlpha)
+        }
+        let (rms, mx, inl) = stats(residuals)
+        return FittedPrimitive(kind: .cone,
+                               params: [apex.x, apex.y, apex.z, axis.x, axis.y, axis.z, alpha],
+                               residualRMS: rms, residualMax: mx, inlierRatio: inl)
+    }
+
+    // MARK: Helpers
+
+    static func regionPoints(vertices: [SIMD3<Float>], indices: [UInt32], region: MeshRegion) -> [SIMD3<Double>] {
+        var seen = Set<UInt32>()
+        var pts: [SIMD3<Double>] = []
+        for t in region.triangleIndices {
+            let base = t * 3
+            for g in [indices[base], indices[base + 1], indices[base + 2]] where seen.insert(g).inserted {
+                pts.append(SIMD3<Double>(vertices[Int(g)]))
+            }
+        }
+        return pts
+    }
+
+    /// (rms, max, inlierRatio) of residuals. Inlier = within max(2·rms, 1e-4).
+    static func stats(_ residuals: [Double]) -> (Double, Double, Double) {
+        guard !residuals.isEmpty else { return (.infinity, .infinity, 0) }
+        var sumSq = 0.0, mx = 0.0
+        for r in residuals { sumSq += r * r; mx = max(mx, r) }
+        let rms = (sumSq / Double(residuals.count)).squareRoot()
+        let tol = max(2 * rms, 1e-4)
+        let inliers = residuals.reduce(0) { $0 + ($1 <= tol ? 1 : 0) }
+        return (rms, mx, Double(inliers) / Double(residuals.count))
+    }
+}

--- a/Sources/OCCTSwiftMesh/SegmentOptions.swift
+++ b/Sources/OCCTSwiftMesh/SegmentOptions.swift
@@ -1,0 +1,59 @@
+// SegmentOptions — input parameters for Mesh.segmented(_:).
+
+import OCCTSwift
+
+/// Parameters controlling dihedral region-growing + primitive-fit merge.
+///
+/// ## Example
+///
+/// ```swift
+/// var options = Mesh.SegmentOptions()
+/// options.maxDihedralDegrees = 15
+/// let segmented = mesh.segmented(options)
+/// ```
+extension Mesh {
+    public struct SegmentOptions: Sendable {
+        /// Region-growing breaks where the dihedral angle between adjacent face normals
+        /// exceeds this threshold.
+        public var maxDihedralDegrees: Float
+
+        /// Merge tolerance as a fraction of the mesh's bounding-box diagonal: a merge is
+        /// accepted only when the union still fits a single primitive within
+        /// `max(mergeRelativeTolerance × bboxDiagonal, 1e-6)`.
+        public var mergeRelativeTolerance: Double
+
+        /// Two adjacent regions are only merge-eligible when even their sharpest shared
+        /// boundary edge is below this dihedral angle — what distinguishes a coarse
+        /// cylinder's shallow facet seams from a box's 90° corner.
+        public var maxMergeAngleDegrees: Float
+
+        /// Regions smaller than this (after growing + merging) are dropped from the result
+        /// and their triangles counted in `SegmentedMesh.truncatedTriangleCount`.
+        public var minRegionTriangles: Int
+
+        /// Cap on the number of regions returned. When set and exceeded, the largest
+        /// `maxRegions` regions are kept and the rest counted in
+        /// `SegmentedMesh.truncatedTriangleCount` — truncation is always reported, never silent.
+        public var maxRegions: Int?
+
+        /// Forwarded to the internal weld pass that establishes adjacency. `0` (default)
+        /// auto-derives `1e-6 ×` the mesh's bounding-box diagonal.
+        public var weldTolerance: Double
+
+        public init(
+            maxDihedralDegrees: Float = 20,
+            mergeRelativeTolerance: Double = 0.004,
+            maxMergeAngleDegrees: Float = 50,
+            minRegionTriangles: Int = 1,
+            maxRegions: Int? = nil,
+            weldTolerance: Double = 0
+        ) {
+            self.maxDihedralDegrees = maxDihedralDegrees
+            self.mergeRelativeTolerance = mergeRelativeTolerance
+            self.maxMergeAngleDegrees = maxMergeAngleDegrees
+            self.minRegionTriangles = minRegionTriangles
+            self.maxRegions = maxRegions
+            self.weldTolerance = weldTolerance
+        }
+    }
+}

--- a/Sources/OCCTSwiftMesh/SegmentedMesh.swift
+++ b/Sources/OCCTSwiftMesh/SegmentedMesh.swift
@@ -1,0 +1,19 @@
+// SegmentedMesh — successful result of Mesh.segmented(_:).
+
+/// A mesh split into surface regions, each with its best-fit primitive.
+public struct SegmentedMesh: Sendable {
+    /// Segmented regions, largest-first. `fits[i]` is the primitive fitted to `regions[i]`.
+    public let regions: [MeshRegion]
+    public let fits: [FittedPrimitive]
+
+    /// Triangles excluded from `regions` because the raw result exceeded
+    /// `SegmentOptions.maxRegions` (the smallest regions were dropped) or fell under
+    /// `SegmentOptions.minRegionTriangles`. `0` when nothing was truncated.
+    public let truncatedTriangleCount: Int
+
+    public init(regions: [MeshRegion], fits: [FittedPrimitive], truncatedTriangleCount: Int) {
+        self.regions = regions
+        self.fits = fits
+        self.truncatedTriangleCount = truncatedTriangleCount
+    }
+}

--- a/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
@@ -1,0 +1,167 @@
+import simd
+import OCCTSwift
+
+// Shared synthetic-mesh builders for the mesh-foundations and segmentation test suites.
+// All pure geometry — no OCCT tessellation needed, mirroring CrossSectionTests' approach.
+
+/// A unit cube, corner at the origin, vertices SHARED across faces (8 vertices, 12 triangles) —
+/// already welded by construction.
+func weldedUnitCube() -> Mesh {
+    let p: [SIMD3<Float>] = [
+        SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(1, 1, 0), SIMD3(0, 1, 0),
+        SIMD3(0, 0, 1), SIMD3(1, 0, 1), SIMD3(1, 1, 1), SIMD3(0, 1, 1),
+    ]
+    let faces = [[0, 1, 2, 3], [4, 5, 6, 7], [0, 1, 5, 4], [2, 3, 7, 6], [1, 2, 6, 5], [0, 3, 7, 4]]
+    var indices: [UInt32] = []
+    for f in faces {
+        indices.append(contentsOf: [UInt32(f[0]), UInt32(f[1]), UInt32(f[2])])
+        indices.append(contentsOf: [UInt32(f[0]), UInt32(f[2]), UInt32(f[3])])
+    }
+    return Mesh(vertices: p, indices: indices)!
+}
+
+/// The same unit cube, but EVERY triangle gets its own 3 fresh vertices (36 vertices total, 12
+/// triangles, no two triangles sharing an index anywhere) — the fully-unshared "soup" that raw
+/// OCCT tessellation / STL import actually produces. Geometrically identical to
+/// `weldedUnitCube()`; welding should collapse it back to 8 vertices.
+func unweldedUnitCube() -> Mesh {
+    let corners: [SIMD3<Float>] = [
+        SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(1, 1, 0), SIMD3(0, 1, 0),
+        SIMD3(0, 0, 1), SIMD3(1, 0, 1), SIMD3(1, 1, 1), SIMD3(0, 1, 1),
+    ]
+    let faces = [[0, 1, 2, 3], [4, 5, 6, 7], [0, 1, 5, 4], [2, 3, 7, 6], [1, 2, 6, 5], [0, 3, 7, 4]]
+    var positions: [SIMD3<Float>] = []
+    var indices: [UInt32] = []
+    for f in faces {
+        let quad = f.map { corners[$0] }
+        for tri in [[quad[0], quad[1], quad[2]], [quad[0], quad[2], quad[3]]] {
+            let base = UInt32(positions.count)
+            positions.append(contentsOf: tri)
+            indices.append(contentsOf: [base, base + 1, base + 2])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// Two unit cubes far apart, each welded internally but sharing no vertices with the other —
+/// two connected components.
+func disjointCubesMesh() -> Mesh {
+    let a = weldedUnitCube()
+    let b = weldedUnitCube()
+    let offset = SIMD3<Float>(100, 100, 100)
+    let positions = a.vertices + b.vertices.map { $0 + offset }
+    let bBase = UInt32(a.vertices.count)
+    let indices = a.indices + b.indices.map { $0 + bBase }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// An open cylindrical tube (barrel only, no end caps), welded by construction: shared ring
+/// vertices at every angular step. One connected component; boundary is exactly the top and
+/// bottom rim — 2 boundary loops.
+func openCylinderShellMesh(radius: Float = 3, height: Float = 5, segments: Int = 16) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    for k in 0..<2 {
+        let z = Float(k) * height
+        for i in 0..<segments {
+            let a = Float(i) / Float(segments) * 2 * .pi
+            positions.append(SIMD3(radius * cos(a), radius * sin(a), z))
+        }
+    }
+    var indices: [UInt32] = []
+    let lo: UInt32 = 0, hi = UInt32(segments)
+    for i in 0..<segments {
+        let a = lo + UInt32(i), b = lo + UInt32((i + 1) % segments)
+        let c = hi + UInt32(i), d = hi + UInt32((i + 1) % segments)
+        indices.append(contentsOf: [a, b, c, b, d, c])
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A coarse capped cylinder: `sides`-sided barrel (adjacent facets 360/sides° apart — coarse
+/// enough to shatter under a 20° dihedral threshold) plus flat top/bottom disk caps. Welded by
+/// construction. Segmentation should merge the shattered barrel facets back into one cylinder
+/// region, while the caps (already-coplanar fans) stay separate — 3 regions total.
+func coarseCappedCylinderMesh(radius: Float = 4, sides: Int = 12, rings: Int = 5, height: Float = 4) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    for k in 0..<rings {
+        let z = Float(k) / Float(rings - 1) * height
+        for i in 0..<sides {
+            let a = Float(i) / Float(sides) * 2 * .pi
+            positions.append(SIMD3(radius * cos(a), radius * sin(a), z))
+        }
+    }
+    let bottomCenter = UInt32(positions.count); positions.append(SIMD3(0, 0, 0))
+    let topCenter = UInt32(positions.count); positions.append(SIMD3(0, 0, height))
+
+    var indices: [UInt32] = []
+    for k in 0..<(rings - 1) {
+        let lo = UInt32(k * sides), hi = UInt32((k + 1) * sides)
+        for i in 0..<sides {
+            let a = lo + UInt32(i), b = lo + UInt32((i + 1) % sides)
+            let c = hi + UInt32(i), d = hi + UInt32((i + 1) % sides)
+            indices.append(contentsOf: [a, b, c, b, d, c])
+        }
+    }
+    for i in 0..<sides {
+        let a = UInt32(i), b = UInt32((i + 1) % sides)
+        indices.append(contentsOf: [bottomCenter, b, a])
+    }
+    let topRingBase = UInt32((rings - 1) * sides)
+    for i in 0..<sides {
+        let a = topRingBase + UInt32(i), b = topRingBase + UInt32((i + 1) % sides)
+        indices.append(contentsOf: [topCenter, a, b])
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A closed, orientable tetrahedron plus one extra degenerate triangle that references a fresh,
+/// otherwise-unused vertex — that vertex becomes an orphan once the degenerate triangle is
+/// dropped during `integrityReport()`'s cleanup pass.
+func tetrahedronWithOrphanDegenerateTriangle() -> Mesh {
+    let base = orientableTetrahedronMesh()
+    var positions = base.vertices
+    positions.append(SIMD3(5, 5, 5))
+    var indices = base.indices
+    indices.append(contentsOf: [0, 0, UInt32(positions.count - 1)])   // degenerate: repeats vertex 0
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// Three triangles sharing one edge (a "book") — a non-manifold EDGE (valence 3), no
+/// non-manifold vertex.
+func nonManifoldEdgeFixture() -> Mesh {
+    let p: [SIMD3<Float>] = [
+        SIMD3(0, 0, 0), SIMD3(1, 0, 0),   // shared edge (0, 1)
+        SIMD3(0, 1, 0), SIMD3(0, -1, 0), SIMD3(0, 0, 1),
+    ]
+    let indices: [UInt32] = [0, 1, 2, 1, 0, 3, 0, 1, 4]
+    return Mesh(vertices: p, indices: indices)!
+}
+
+/// Two triangles sharing exactly one vertex (a "bowtie" pinch point) — a non-manifold VERTEX,
+/// no non-manifold edge.
+func bowtieVertexFixture() -> Mesh {
+    let p: [SIMD3<Float>] = [
+        SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0),   // triangle A, shares vertex index 2
+        SIMD3(0, 1, 1), SIMD3(1, 1, 1),                   // triangle B
+    ]
+    let indices: [UInt32] = [0, 1, 2, 2, 3, 4]
+    return Mesh(vertices: p, indices: indices)!
+}
+
+/// A closed, watertight tetrahedron with hand-verified CONSISTENT outward winding (every shared
+/// edge is traversed in opposite directions by its two triangles) — for asserting
+/// `isOrientable`/`genus`, which need a known-consistent fixture rather than an
+/// orientation-agnostic one.
+func orientableTetrahedronMesh() -> Mesh {
+    let p: [SIMD3<Float>] = [SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1)]
+    let indices: [UInt32] = [0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3]
+    return Mesh(vertices: p, indices: indices)!
+}
+
+/// One valid triangle, an exact duplicate of it, and a triangle that degenerates to a repeated
+/// vertex once vertex 3 (coincident with vertex 0) is welded.
+func duplicateAndDegenerateFixture() -> Mesh {
+    let p: [SIMD3<Float>] = [SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 0)]
+    let indices: [UInt32] = [0, 1, 2, 0, 1, 2, 0, 3, 1]
+    return Mesh(vertices: p, indices: indices)!
+}

--- a/Tests/OCCTSwiftMeshTests/MeshFoundationsTests.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshFoundationsTests.swift
@@ -1,0 +1,256 @@
+import Testing
+import simd
+import OCCTSwift
+@testable import OCCTSwiftMesh
+
+@Suite("Mesh.welded — vertex welding")
+struct WeldingTests {
+    @Test("Per-triangle-unique-vertex box welds down to the shared-vertex form")
+    func unweldedCubeWelds() {
+        let cube = unweldedUnitCube()
+        #expect(cube.vertexCount == 36)
+        let welded = cube.welded()
+        #expect(welded.vertexCount == 8)
+        #expect(welded.triangleCount == 12)
+    }
+
+    @Test("Welding an already-welded mesh is idempotent")
+    func weldIdempotence() {
+        let once = unweldedUnitCube().welded()
+        let twice = once.welded()
+        #expect(once.vertexCount == twice.vertexCount)
+        #expect(once.triangleCount == twice.triangleCount)
+
+        let alreadyWelded = weldedUnitCube()
+        let stillWelded = alreadyWelded.welded()
+        #expect(stillWelded.vertexCount == alreadyWelded.vertexCount)
+        #expect(stillWelded.triangleCount == alreadyWelded.triangleCount)
+    }
+
+    @Test("Tolerance controls whether near-coincident vertices merge")
+    func weldToleranceBoundary() {
+        // P0/P1 are 0.0003 apart — well inside a single grid cell at tolerance 0.001 (ratio
+        // 0.3, rounds to the same cell as P0) and well outside one at tolerance 0.0001 (ratio
+        // 3.0, three cells away): comfortably clear of the grid-hash's cell-boundary rounding
+        // ambiguity in either direction.
+        let p: [SIMD3<Float>] = [
+            SIMD3(0, 0, 0), SIMD3(0, 0, 0.0003), SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(1, 1, 1),
+        ]
+        let mesh = Mesh(vertices: p, indices: [0, 2, 3, 1, 2, 4])!
+
+        let tight = mesh.welded(tolerance: 0.0001)
+        #expect(tight.vertexCount == 5)
+        #expect(tight.triangleCount == 2)
+
+        let loose = mesh.welded(tolerance: 0.001)
+        #expect(loose.vertexCount == 4)
+        #expect(loose.triangleCount == 2)
+    }
+
+    @Test("Extreme coincident coordinates don't overflow the grid-hash key")
+    func hugeCoincidentCoordinatesDoNotCrash() {
+        // diag == 0 (every vertex identical) floors the cell size to 1e-9; combined with
+        // coordinates of this magnitude, the naive (unclamped) grid coordinate overflows
+        // Int64 on conversion. Reaching the assertion at all is the regression check.
+        let huge: Float = 1e13
+        let p: [SIMD3<Float>] = [SIMD3(huge, huge, huge), SIMD3(huge, huge, huge), SIMD3(huge, huge, huge)]
+        let mesh = Mesh(vertices: p, indices: [0, 1, 2])!
+        let welded = mesh.welded()
+        #expect(welded.vertexCount >= 1)
+    }
+}
+
+@Suite("Mesh — connectivity toolkit")
+struct TopologyTests {
+    @Test("faceNormals are unit length")
+    func faceNormalsUnitLength() {
+        let cube = weldedUnitCube()
+        for n in cube.faceNormals() {
+            #expect(abs(Double(simd_length(n)) - 1) < 1e-5)
+        }
+    }
+
+    @Test("vertexNormals are unit length")
+    func vertexNormalsUnitLength() {
+        let cube = weldedUnitCube()
+        for n in cube.vertexNormals() {
+            #expect(abs(Double(simd_length(n)) - 1) < 1e-5)
+        }
+    }
+
+    @Test("Each triangle of a closed welded box has exactly 3 adjacent triangles")
+    func adjacencyOnWeldedBox() {
+        let cube = weldedUnitCube()
+        let adjacency = cube.triangleAdjacency()
+        #expect(adjacency.count == 12)
+        for neighbors in adjacency { #expect(neighbors.count == 3) }
+    }
+
+    @Test("Unwelded input has no adjacency — documents the weld precondition")
+    func adjacencyRequiresWeld() {
+        let cube = unweldedUnitCube()
+        let adjacency = cube.triangleAdjacency()
+        for neighbors in adjacency { #expect(neighbors.isEmpty) }
+    }
+
+    @Test("A closed welded box is one connected component")
+    func connectedComponentsOfBox() {
+        let cube = weldedUnitCube()
+        let components = cube.connectedComponents()
+        #expect(components.count == 1)
+        #expect(components[0].triangleIndices.count == 12)
+        #expect(components[0].area > 0)
+    }
+
+    @Test("Two disjoint boxes are two connected components, deterministically ordered")
+    func connectedComponentsOfDisjointBoxes() {
+        let mesh = disjointCubesMesh()
+        let a = mesh.connectedComponents()
+        let b = mesh.connectedComponents()
+        #expect(a.count == 2)
+        #expect(a[0].triangleIndices.count == 12)
+        #expect(a[1].triangleIndices.count == 12)
+        #expect(a.map(\.triangleIndices) == b.map(\.triangleIndices))
+        // Tie-break: equal-size components ordered by lowest triangle index.
+        #expect(a[0].triangleIndices.min() == 0)
+        #expect(a[1].triangleIndices.min() == 12)
+    }
+
+    @Test("Unwelded input is every triangle its own component — documents the weld precondition")
+    func componentsRequireWeld() {
+        let cube = unweldedUnitCube()
+        #expect(cube.connectedComponents().count == 12)
+    }
+
+    @Test("subMesh extracts a compact, self-contained mesh")
+    func subMeshExtraction() throws {
+        let cube = weldedUnitCube()
+        let face = try #require(cube.subMesh(triangleIndices: [0, 1]))
+        #expect(face.triangleCount == 2)
+        #expect(face.vertexCount == 4)
+        let bound = UInt32(face.vertexCount)
+        #expect(face.indices.allSatisfy { $0 < bound })
+    }
+
+    @Test("subMesh returns nil for an empty triangle list")
+    func subMeshEmpty() {
+        let cube = weldedUnitCube()
+        #expect(cube.subMesh(triangleIndices: []) == nil)
+    }
+
+    @Test("subMesh silently skips out-of-range triangle indices instead of crashing")
+    func subMeshOutOfRangeIndices() throws {
+        let cube = weldedUnitCube()
+        let face = try #require(cube.subMesh(triangleIndices: [0, 100, -5]))
+        #expect(face.triangleCount == 1)
+
+        #expect(cube.subMesh(triangleIndices: [100, -5]) == nil)
+    }
+
+    @Test("An open cylindrical shell has one component and two boundary loops")
+    func boundaryLoopsOfOpenShell() {
+        let shell = openCylinderShellMesh(segments: 16)
+        #expect(shell.connectedComponents().count == 1)
+        let loops = shell.boundaryLoops()
+        #expect(loops.count == 2)
+        for loop in loops { #expect(loop.count == 16) }
+    }
+
+    @Test("A closed welded box has no boundary loops")
+    func boundaryLoopsOfClosedBox() {
+        #expect(weldedUnitCube().boundaryLoops().isEmpty)
+    }
+}
+
+@Suite("Mesh.integrityReport — validity & quality snapshot")
+struct IntegrityReportTests {
+    @Test("A closed welded box is watertight, with the expected Euler characteristic")
+    func closedBoxReport() {
+        let report = weldedUnitCube().integrityReport()
+        #expect(report.isWatertight)
+        #expect(report.nonManifoldEdgeCount == 0)
+        #expect(report.nonManifoldVertexCount == 0)
+        #expect(report.boundaryLoopCount == 0)
+        #expect(report.duplicateTriangleCount == 0)
+        #expect(report.degenerateTriangleCount == 0)
+        #expect(report.eulerCharacteristic == 2)
+        #expect(report.components.count == 1)
+        #expect(report.components[0].triangleCount == 12)
+    }
+
+    @Test("A closed, consistently-wound tetrahedron is watertight, orientable, genus 0")
+    func orientableClosedSurfaceReport() {
+        let report = orientableTetrahedronMesh().integrityReport()
+        #expect(report.isWatertight)
+        #expect(report.isOrientable)
+        #expect(report.eulerCharacteristic == 2)
+        #expect(report.genus == 0)
+    }
+
+    @Test("A dropped degenerate triangle's orphaned vertex doesn't corrupt Euler characteristic / genus")
+    func orphanedVertexFromDegenerateTriangleDoesNotSkewEuler() {
+        // Same closed tetrahedron as above (Euler 2, genus 0) plus an extra degenerate triangle
+        // that references a fresh, otherwise-unused vertex. That vertex must NOT count toward V
+        // once its only triangle is dropped as degenerate.
+        let report = tetrahedronWithOrphanDegenerateTriangle().integrityReport()
+        #expect(report.degenerateTriangleCount == 1)
+        #expect(report.isWatertight)
+        #expect(report.isOrientable)
+        #expect(report.eulerCharacteristic == 2)
+        #expect(report.genus == 0)
+    }
+
+    @Test("An open shell reports its two boundary loops and is not watertight")
+    func openShellReport() {
+        let report = openCylinderShellMesh(segments: 16).integrityReport()
+        #expect(!report.isWatertight)
+        #expect(report.boundaryLoopCount == 2)
+        #expect(report.nonManifoldEdgeCount == 0)
+    }
+
+    @Test("An edge shared by three triangles is reported as non-manifold")
+    func nonManifoldEdgeReport() {
+        let report = nonManifoldEdgeFixture().integrityReport()
+        #expect(report.nonManifoldEdgeCount == 1)
+        #expect(!report.isWatertight)
+    }
+
+    @Test("A pinch-point vertex is reported as non-manifold")
+    func nonManifoldVertexReport() {
+        let report = bowtieVertexFixture().integrityReport()
+        #expect(report.nonManifoldVertexCount == 1)
+    }
+
+    @Test("Duplicate and degenerate triangles are counted from the raw topology")
+    func duplicateAndDegenerateReport() {
+        let report = duplicateAndDegenerateFixture().integrityReport()
+        #expect(report.duplicateTriangleCount == 1)
+        #expect(report.degenerateTriangleCount == 1)
+    }
+
+    @Test("Sliver signals are finite and in a sane range for a right-angled box")
+    func sliverSignalsSane() {
+        let report = weldedUnitCube().integrityReport()
+        #expect(report.minAngleDegrees.min > 0)
+        #expect(report.minAngleDegrees.min <= 45 + 1e-6)
+        #expect(report.minAngleDegrees.p05 >= report.minAngleDegrees.min)
+        #expect(report.aspectRatio.max >= 1.0 - 1e-6)
+        #expect(report.aspectRatio.max.isFinite)
+        #expect(report.aspectRatio.p95 <= report.aspectRatio.max)
+    }
+
+    @Test("Repeated calls on the same mesh are byte-identical (determinism)")
+    func determinism() {
+        let mesh = coarseCappedCylinderMesh()
+        let a = mesh.integrityReport()
+        let b = mesh.integrityReport()
+        #expect(a.isWatertight == b.isWatertight)
+        #expect(a.isOrientable == b.isOrientable)
+        #expect(a.nonManifoldEdgeCount == b.nonManifoldEdgeCount)
+        #expect(a.nonManifoldVertexCount == b.nonManifoldVertexCount)
+        #expect(a.boundaryLoopCount == b.boundaryLoopCount)
+        #expect(a.eulerCharacteristic == b.eulerCharacteristic)
+        #expect(a.genus == b.genus)
+        #expect(a.components.map(\.triangleCount) == b.components.map(\.triangleCount))
+    }
+}

--- a/Tests/OCCTSwiftMeshTests/MeshSegmentationTests.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshSegmentationTests.swift
@@ -1,0 +1,109 @@
+import Testing
+import simd
+import OCCTSwift
+@testable import OCCTSwiftMesh
+
+@Suite("Mesh.segmented — dihedral region-growing + primitive-fit merge")
+struct SegmentationTests {
+
+    @Test("A box segments into 6 unmerged planar regions")
+    func boxSegmentsIntoSixRegions() {
+        let result = weldedUnitCube().segmented()
+        #expect(result.regions.count == 6)
+        #expect(result.fits.count == 6)
+        #expect(result.truncatedTriangleCount == 0)
+        for fit in result.fits {
+            #expect(fit.kind == .plane)
+            #expect(fit.residualRMS < 1e-5)
+        }
+        // Box faces meet at 90°, well outside maxMergeAngleDegrees (50°) — must NOT fuse.
+        for region in result.regions { #expect(region.triangleIndices.count == 2) }
+    }
+
+    @Test("Unwelded box still segments into 6 regions — weld precondition is handled internally")
+    func unweldedBoxStillSegments() {
+        let result = unweldedUnitCube().segmented()
+        #expect(result.regions.count == 6)
+        for region in result.regions { #expect(region.triangleIndices.count == 2) }
+    }
+
+    @Test("A coarse capped cylinder merges its shattered barrel facets back into one cylinder")
+    func coarseCylinderMergesToBarrelPlusCaps() {
+        let mesh = coarseCappedCylinderMesh(radius: 4, sides: 12, rings: 5, height: 4)
+
+        // Sanity: smooth region-growing alone shatters the coarse barrel — adjacent facets are
+        // 30° apart, past the 20° default dihedral threshold, so each becomes its own region
+        // before the merge pass runs.
+        let normals = mesh.faceNormals()
+        let adjacency = mesh.triangleAdjacency()
+        let seeded = Mesh.segmentSmoothRegions(triangleCount: mesh.triangleCount, normals: normals,
+                                               adjacency: adjacency, maxDihedralDegrees: 20)
+        // 12 vertical barrel strips (each internally coplanar top-to-bottom) + 2 flat cap fans.
+        #expect(seeded.count == 14)
+
+        let result = mesh.segmented()
+        #expect(result.regions.count == 3)
+        let cylinders = result.fits.filter { $0.kind == .cylinder }
+        let planes = result.fits.filter { $0.kind == .plane }
+        #expect(cylinders.count == 1)
+        #expect(planes.count == 2)
+        if let radius = cylinders.first?.radius {
+            #expect(abs(radius - 4) < 0.15)
+        }
+    }
+
+    @Test("An open cylindrical shell (no caps) merges into a single cylinder region")
+    func openShellSegmentsToOneCylinder() {
+        // The "open half-cylinder shell" case from the tracking issue: an uncapped barrel, only
+        // the round wall — coarse enough (12 sides, 30° apart) to shatter under the default 20°
+        // dihedral threshold, with nothing else present for the merge to confuse it with.
+        let mesh = openCylinderShellMesh(radius: 4, height: 4, segments: 12)
+        let result = mesh.segmented()
+        #expect(result.regions.count == 1)
+        #expect(result.fits.first?.kind == .cylinder)
+        if let radius = result.fits.first?.radius {
+            #expect(abs(radius - 4) < 0.15)
+        }
+    }
+
+    @Test("Segmentation is deterministic across repeated calls")
+    func determinism() {
+        let mesh = coarseCappedCylinderMesh()
+        let a = mesh.segmented()
+        let b = mesh.segmented()
+        #expect(a.regions.map(\.triangleIndices) == b.regions.map(\.triangleIndices))
+        #expect(a.regions.map(\.area) == b.regions.map(\.area))
+        #expect(a.fits.map(\.kind) == b.fits.map(\.kind))
+        #expect(a.fits.map(\.params) == b.fits.map(\.params))
+        #expect(a.truncatedTriangleCount == b.truncatedTriangleCount)
+    }
+
+    @Test("maxRegions caps the result and reports the truncated triangle count, never silently")
+    func maxRegionsCapsAndReports() {
+        var options = Mesh.SegmentOptions()
+        options.maxRegions = 3
+        let result = weldedUnitCube().segmented(options)
+        #expect(result.regions.count == 3)
+        #expect(result.truncatedTriangleCount == 6)   // 3 dropped regions × 2 triangles each
+    }
+
+    @Test("A negative maxRegions is treated as zero rather than crashing")
+    func negativeMaxRegionsDoesNotCrash() {
+        var options = Mesh.SegmentOptions()
+        options.maxRegions = -1
+        let result = weldedUnitCube().segmented(options)
+        #expect(result.regions.isEmpty)
+        #expect(result.fits.isEmpty)
+        #expect(result.truncatedTriangleCount == 12)
+    }
+
+    @Test("minRegionTriangles drops undersized regions and reports them as truncated")
+    func minRegionTrianglesFiltersAndReports() {
+        var options = Mesh.SegmentOptions()
+        options.minRegionTriangles = 3   // every box region has only 2 triangles
+        let result = weldedUnitCube().segmented(options)
+        #expect(result.regions.isEmpty)
+        #expect(result.fits.isEmpty)
+        #expect(result.truncatedTriangleCount == 12)
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,72 @@
 
 All notable changes to OCCTSwiftMesh.
 
+## v1.2.0 — mesh foundations + region segmentation
+
+Adds the mesh connectivity toolkit ([#16](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/16))
+and dihedral region-growing + primitive-fit segmentation
+([#17](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/17)) — both pure Swift + simd, no
+OCCT kernel calls, ported from OCCTReconstruct's `ReconstructCompute` reference implementation.
+
+**Mesh foundations** (`Mesh+Welding.swift`, `Mesh+Topology.swift`, `MeshIntegrityReport.swift`):
+
+```swift
+let welded = mesh.welded(tolerance: 0)        // 0 auto-derives 1e-6 × bbox diagonal
+welded.faceNormals()                          // [SIMD3<Float>], one per triangle
+welded.vertexNormals()                        // area-weighted, per vertex
+welded.triangleAdjacency()                    // [[Int]] — edge-adjacent triangles
+welded.connectedComponents()                  // [MeshRegion], largest-first
+welded.subMesh(triangleIndices:)               // extract a compact standalone Mesh, or nil
+welded.boundaryLoops()                        // [[UInt32]] — open-edge rings
+mesh.integrityReport()                        // MeshIntegrityReport — welds internally
+```
+
+- `triangleAdjacency()`, `connectedComponents()`, and `boundaryLoops()` key connectivity off
+  shared vertex INDICES — they need welded input. Raw OCCT tessellation and STL import produce
+  per-triangle-unique vertices (no two triangles share an index at all), so call `.welded()`
+  first or every triangle comes back isolated. This is a deliberate, documented precondition, not
+  an oversight — see each method's doc comment.
+- `integrityReport()` welds internally (so it's safe to call on raw input directly) but counts
+  `duplicateTriangleCount` / `degenerateTriangleCount` from the RAW welded topology before
+  cleanup, while every other metric (manifoldness, Euler characteristic, genus, components,
+  sliver signals) is computed on the deduplicated, non-degenerate topology — so a handful of
+  exact duplicate faces doesn't masquerade as a real non-manifold defect.
+- Semantics follow the Open3D `TriangleMesh` conventions (`is_edge_manifold` /
+  `is_vertex_manifold` / `is_watertight` / `cluster_connected_triangles`).
+- `genus` is `nil` unless the mesh is watertight and orientable; computed additively across all
+  closed components (`genus = components.count - eulerCharacteristic / 2`).
+
+**Segmentation** (`Mesh+Segmentation.swift`, `PrimitiveFitter.swift`, `FittedPrimitive.swift`):
+
+```swift
+let segmented = mesh.segmented(.init(maxDihedralDegrees: 20))
+for (region, fit) in zip(segmented.regions, segmented.fits) {
+    print(region.triangleIndices.count, fit.kind, fit.residualRMS)
+}
+```
+
+- Region-growing breaks at sharp edges (`maxDihedralDegrees`, default 20°); the merge pass then
+  greedily unions adjacent regions whose union still fits a single plane/cylinder/sphere/cone
+  within `mergeRelativeTolerance × bboxDiagonal`, undoing coarse-tessellation "confetti" (a
+  12-facet cylinder's facets, each past the dihedral threshold, merge back into one cylinder).
+  A cube's 90° corners are correctly left unmerged.
+- Welds internally (`SegmentOptions.weldTolerance`) — unwelded input does not silently degrade to
+  one region per triangle; every `MeshRegion.triangleIndices` still refers to the input mesh's
+  own (possibly unwelded) triangle order.
+- A cheap coplanar pre-merge (fit-free, ~2° threshold) runs before the fit-gated pass whenever
+  the raw region count exceeds an internal cap (1500, matching the OCCTReconstruct reference),
+  keeping segmentation usable at 400k+ triangle scan meshes.
+- `SegmentOptions.maxRegions` / `minRegionTriangles` never truncate silently:
+  `SegmentedMesh.truncatedTriangleCount` reports exactly how many triangles were dropped and why.
+- Determinism is load-bearing, not incidental: region composition, merge order, and boundary-loop
+  chaining all have explicit tie-breaks (documented inline) so two runs on identical input
+  produce byte-identical output — Dictionary/Set iteration order is NOT a substitute.
+- Out of scope for this release (tracked as follow-ups per #17): curvature-based seeding, the
+  Schnabel-style RANSAC alternative strategy + auto-selection bake-off, and slippage analysis.
+
+New public types: `MeshRegion`, `MeshIntegrityReport`, `Mesh.SegmentOptions`, `SegmentedMesh`,
+`FittedPrimitive` (+ nested `FittedPrimitive.Kind`).
+
 ## v1.1.6 — repin OCCTSwift 1.12.9 (#318 and #323 crash/hang fixes)
 
 Repin the OCCTSwift floor to **1.12.9**, which carries kernel patch 0006 (a `BRepGProp_EdgeTool` null-curve-on-surface guard, [OCCTSwift#318](https://github.com/SecondMouseAU/OCCTSwift/issues/318)) and patches 0007 through 0009 (free-bounds `lwire` reset, boolean-path BSpline O(1) periodic normalization, STEP-writer oversized-string split; [OCCTSwift#323](https://github.com/SecondMouseAU/OCCTSwift/issues/323)), on top of the earlier patches. No API or behaviour change.

--- a/docs/algorithms/mesh-foundations.md
+++ b/docs/algorithms/mesh-foundations.md
@@ -1,0 +1,98 @@
+# Mesh foundations (`Mesh.welded(_:)` and the connectivity toolkit)
+
+Weld, per-triangle-adjacency, connected components, sub-mesh extraction, boundary loops, and a
+manifoldness/validity/quality report (`MeshIntegrityReport`). Pure Swift + simd — no OCCT kernel
+calls — ported from OCCTReconstruct's `ReconstructCompute.IndexedMesh` / `MeshRepair` /
+`MeshClosing`, adapted to operate directly on `OCCTSwift.Mesh`'s own `vertices`/`indices` arrays.
+
+## Why weld first
+
+OCCT tessellation and STL loading both produce (near-)unshared vertices in practice: three
+unique positions per triangle, even where two triangles are geometrically edge-adjacent. Every
+adjacency-based primitive here (`triangleAdjacency`, `connectedComponents`, `boundaryLoops`)
+keys its connectivity off shared VERTEX INDICES, not positions — so on unwelded input, no two
+triangles share an index and each comes back looking isolated (every triangle its own component,
+every edge a "boundary"). `welded(tolerance:)` is the deliberate, documented prerequisite.
+
+`integrityReport()` and `segmented(_:)` (see [segmentation.md](segmentation.md)) weld internally
+instead, precisely because unwelded input silently degrading to a meaningless result (a
+non-manifold report with zero non-manifold edges; one segmentation region per triangle) is a
+worse failure mode than the extra weld pass's cost.
+
+## Weld algorithm: grid-hash, not radius search
+
+`welded(tolerance:)` snaps each vertex to a spatial grid cell (`tolerance`, or `1e-6 ×` the
+bounding-box diagonal when `0`) and merges every vertex landing in the same cell, keeping the
+first-encountered position as the cell's representative. This is the same technique
+`crossSection`'s intersection-point welding already uses in this package (`CrossSection.swift`),
+kept for consistency.
+
+**Known limitation** (inherited from that same precedent): two points within `tolerance` of each
+other but straddling a grid-cell boundary can round into different cells and fail to merge. The
+cell size is tiny relative to the model by default (`1e-6 ×` bbox diagonal), far below any real
+wall thickness, so this only bites when a caller passes an explicit `tolerance` and places points
+adversarially close to a cell boundary — not a concern in practice, and not worth the complexity
+of a proper neighbor-cell radius search for a foundational, high-call-volume primitive.
+
+`welded(tolerance:)` also drops any triangle that degenerates (repeats a vertex) as a result of
+welding, since a zero-area triangle would otherwise corrupt every downstream adjacency
+computation. It does NOT drop duplicate (non-degenerate, repeated-vertex-set) triangles — that
+diagnostic is reserved for `integrityReport()`, which surfaces it explicitly rather than silently
+cleaning it up.
+
+## `MeshIntegrityReport` — counted before cleanup vs. computed after
+
+`duplicateTriangleCount` and `degenerateTriangleCount` are counted from the RAW welded topology,
+before any cleanup — that's the whole point of reporting them. Every other metric
+(`isWatertight`, `isOrientable`, `nonManifoldEdgeCount`, `nonManifoldVertexCount`,
+`boundaryLoopCount`, `eulerCharacteristic`, `genus`, `components`, the sliver signals) is computed
+on the deduplicated, non-degenerate topology instead, so a handful of exact duplicate faces
+doesn't masquerade as a real non-manifold defect (a duplicated triangle trivially makes its three
+edges non-manifold — that's noise, not signal).
+
+Semantics follow the [Open3D `TriangleMesh`](https://www.open3d.org/docs/release/tutorial/geometry/mesh.html)
+conventions (`is_edge_manifold` / `is_vertex_manifold` / `is_watertight` /
+`cluster_connected_triangles`) — the cleanest in the field per the tracking issue.
+
+### Non-manifold vertex detection
+
+A vertex `v` is non-manifold if the triangles around it don't form a single fan. For every
+triangle containing `v`, the edge OPPOSITE `v` is one link of `v`'s "umbrella"; in a manifold
+those opposite edges chain into a single simple path (open, at a boundary) or cycle (closed). A
+branch point (an opposite-edge endpoint touched by 3+ opposite edges) or a second disconnected
+chain (a pinch point / bowtie, two cones of triangles touching at exactly one vertex) makes `v`
+non-manifold. Implemented by building the per-vertex "opposite edge" graph and checking max
+degree ≤ 2 and exactly one connected component.
+
+### Genus
+
+`genus` is `nil` unless `isWatertight && isOrientable` (and the Euler characteristic is
+consistent with a valid closed 2-manifold — an odd numerator defensively yields `nil` rather than
+a nonsensical fractional genus). For `C` disjoint closed orientable components,
+`χ_total = Σ(2 − 2gᵢ) = 2C − 2·G_total`, so `genus = (2·components.count − eulerCharacteristic) / 2`.
+
+### Sliver signals
+
+- `minAngleDegrees`: per-triangle smallest interior angle, reduced to `(min, p05)` — the absolute
+  worst case and the 5th percentile (more robust to a single degenerate outlier).
+- `aspectRatio`: `longestEdge / (2·√3·inradius)`, the VTK/FEM convention where an equilateral
+  triangle scores exactly `1.0` and every other triangle scores higher — reduced to `(max, p95)`.
+
+## Determinism
+
+`connectedComponents()` and `boundaryLoops()` both build their groupings from Dictionary/Set
+iteration internally, which is NOT stable across process runs (Swift randomizes hash seeds).
+Both are made deterministic by an explicit tie-break at the point results are materialized:
+
+- `connectedComponents()`: regions sorted largest-first, ties broken by lowest triangle index
+  (`MeshRegion.order`). Bucket MEMBERSHIP is independent of dictionary iteration order (union-find
+  correctness doesn't depend on processing order); only the final SORT needs the tie-break.
+- `boundaryLoops()`: loops are seeded in sorted edge-key order, and each vertex's neighbor list is
+  sorted before the walk. Without this, a different seed chains edges into different loops at
+  non-manifold junctions, changing the result between runs on identical input.
+
+## What's NOT here
+
+Mesh repair (non-manifold membrane removal via generalized winding number, hole-filling/capping)
+stays in OCCTReconstruct's `MeshRepair.swift` / `MeshClosing.swift` — out of scope for this
+release. `integrityReport()` diagnoses; it does not repair.

--- a/docs/algorithms/segmentation.md
+++ b/docs/algorithms/segmentation.md
@@ -1,0 +1,88 @@
+# Segmentation (`Mesh.segmented(_:)`)
+
+Dihedral region-growing followed by a mandatory primitive-fit merge pass, splitting a mesh into
+plane/cylinder/sphere/cone surface regions. Pure Swift + simd — no OCCT kernel calls — ported
+from OCCTReconstruct's `ReconstructCompute` (`RegionSegmentation.swift`, `RegionMerging.swift`,
+`PrimitiveFitting.swift`, `Linalg.swift`), adapted to operate on `OCCTSwift.Mesh`'s own arrays.
+Depends on the mesh foundations layer — see [mesh-foundations.md](mesh-foundations.md).
+
+## Why merging is mandatory, not optional
+
+Region-growing alone shatters a coarsely-tessellated curved surface: a low-poly cylinder's
+adjacent facets sit further apart than `maxDihedralDegrees`, so each becomes its own planar
+region ("confetti"). OCCTReconstruct's own bake-off tests pin this failure mode — substantial-
+clean coverage drops to ~0% on smooth bodies without the merge pass. The merge pass greedily
+unions adjacent regions whose union still fits ONE primitive within tolerance, collapsing those
+facets back into one cylinder, while leaving real edges (a box's 90° corners, a chamfer's
+distinct cone) intact because their union fits nothing well.
+
+## Two normal-vector roles, deliberately kept separate
+
+`segmented(_:)` welds internally (`SegmentOptions.weldTolerance`) to build the ADJACENCY graph —
+region-growing and the merge pass's boundary-dihedral tracking both use face normals computed on
+the WELDED positions. Primitive fitting (`PrimitiveFitter.bestFit`), by contrast, reads points
+from the mesh's ORIGINAL (unwelded) `vertices`/`indices` — fitting wants the truest available
+geometry, unperturbed by weld-snapping, and welding only ever moves a point by less than
+`tolerance`. Region membership (`MeshRegion.triangleIndices`) always refers to the caller's own
+original triangle order and count — welding remaps which triangles are considered neighbors, it
+never drops or reorders triangles the caller sees.
+
+This is why unwelded input does NOT silently degrade to one region per triangle (the failure
+mode the tracking issue explicitly calls out): adjacency is always computed on welded topology
+regardless of whether the input `Mesh` itself was pre-welded.
+
+## Performance: `bestFit`'s `bodyDiag` is hoisted, not recomputed
+
+The OCCTReconstruct reference recomputes the mesh's bounding-box diagonal inside every
+`PrimitiveFitter.bestFit` call (used for an absolute residual floor). `bestFit` is called once
+per candidate region AND once per candidate merge during the fit-gated pass — recomputing an
+O(vertices) bounds scan on every one of those calls is quadratic-ish at scale. This port hoists
+`bodyDiag` to a single computation in `segmented(_:)`, threaded through as a parameter — the
+same math, computed once. Given the tracking issue's explicit "usable at 400k+ triangles"
+requirement, this isn't optional polish.
+
+## Scale: coplanar pre-merge before the fit-gated pass
+
+The fit-gated merge pass is O(regions × primitive-fit) per iteration and capped internally at
+1500 regions (matching the OCCTReconstruct reference) to stay tractable. A 400k+ triangle scan
+can easily produce more raw seed regions than that. Before the fit-gated pass runs, a cheap,
+FIT-FREE coplanar pre-merge (`RegionMerging.coplanarPreMerge`, ~2° threshold) collapses adjacent
+regions whose face normals are nearly identical — this only ever fuses genuinely-flat confetti
+(coarse facets of what should be one plane), never a real curved-surface seam, because a ~2°
+threshold is far tighter than any real edge. A single union-find pass suffices here (unlike the
+fit-gated pass, its merges are unconditional, so there's no need to re-evaluate pending pairs
+after each merge).
+
+## Explicit, never-silent truncation
+
+`SegmentOptions.maxRegions` (cap the OUTPUT to the largest N regions) and `minRegionTriangles`
+(drop undersized regions) both report exactly what they dropped via
+`SegmentedMesh.truncatedTriangleCount`, rather than silently shrinking the result. This mirrors
+the tracking issue's explicit requirement — a cap that silently drops coverage reads as "fully
+segmented" when it wasn't.
+
+## Determinism
+
+Region composition and merge order both depend on decisions that would otherwise be
+Dictionary-iteration-order-dependent (a fresh, randomized hash seed per process run in Swift):
+
+- **Region growing** (`segmentSmoothRegions`) is a pure graph-reachability computation over a
+  fixed adjacency SET — membership doesn't depend on `adjacency[t]`'s internal element order,
+  only on seed order (`0..<triangleCount`, already deterministic).
+- **Region merging**'s pair-processing order is explicitly sorted (softest boundary first,
+  i.e. highest dihedral dot product, tie-broken on the packed region-pair key) rather than left
+  to dictionary iteration — equal-dihedral pairs would otherwise merge in a different order each
+  run, producing different region compositions and non-reproducible fits.
+
+A dedicated determinism test (segment the same mesh twice, compare regions/fits/params exactly)
+guards this — see `MeshSegmentationTests.swift`.
+
+## Out of scope (tracked as follow-ups per issue #17)
+
+- Curvature-based seeding (needs a curvature estimator first — Rusinkiewicz per-face tensor,
+  planned separately).
+- The Schnabel-style RANSAC alternative strategy (`PrimitiveRANSAC` in the OCCTReconstruct
+  reference) and its auto-selection bake-off against dihedral region-growing.
+- Slippage analysis (Gelfand-Guibas: per-region extrude/revolve/helix classification with axes).
+
+These are phased behind the downstream OCCTMCP tool landing, per the tracking issue.

--- a/okf/components/index.md
+++ b/okf/components/index.md
@@ -19,5 +19,12 @@ Public products and targets from `Package.swift`, plus the key API surfaces from
   - `Mesh.crossSection(plane:)` / `Mesh.crossSections(axis:through:spacing:)` — planar slicing of a
     (possibly open/unwelded) mesh into closed contours; the perimeter step a 3D-printer slicer
     performs. Inner-vs-outer is recovered from contour nesting via `contour.depth` / `contour.isHole`.
+  - Mesh foundations — `Mesh.welded(tolerance:)`, `faceNormals()`, `vertexNormals()`,
+    `triangleAdjacency()`, `connectedComponents()`, `subMesh(triangleIndices:)`,
+    `boundaryLoops()`, `integrityReport()`. Adjacency-based operations need a welded mesh;
+    `integrityReport()` welds internally. Pure Swift + simd, no OCCT kernel calls.
+  - `Mesh.segmented(_:)` — dihedral region-growing + primitive-fit merge, splitting a mesh into
+    plane/cylinder/sphere/cone surface regions (`MeshRegion` + `FittedPrimitive` pairs via
+    `SegmentedMesh`). Welds internally; depends on the mesh foundations layer.
 - **`OCCTMeshOptimizer`** (internal C++ bridge target) — vendors meshoptimizer (MIT) and exposes a
   small C ABI consumed by the Swift layer. Not a public product.

--- a/okf/index.md
+++ b/okf/index.md
@@ -2,9 +2,9 @@
 type: repo
 title: OCCTSwiftMesh
 resource: https://github.com/SecondMouseAU/OCCTSwiftMesh
-tags: [cad, occt, mesh, decimation, slicing, swift, kernel]
-description: Mesh-domain algorithms (decimation, planar slicing) for the OCCTSwift ecosystem, operating on OCCTSwift.Mesh instances.
-timestamp: 2026-06-22
+tags: [cad, occt, mesh, decimation, slicing, segmentation, swift, kernel]
+description: Mesh-domain algorithms (decimation, planar slicing, connectivity/integrity toolkit, region segmentation) for the OCCTSwift ecosystem, operating on OCCTSwift.Mesh instances.
+timestamp: 2026-07-21
 ---
 
 # OCCTSwiftMesh
@@ -18,19 +18,24 @@ timestamp: 2026-06-22
 
 - **Cluster:** kernel
 - **Depends on:** [OCCTSwift](https://github.com/SecondMouseAU/OCCTSwift) — source of the `Mesh`
-  type these algorithms operate on (floored at OCCTSwift v1.7.1).
+  type these algorithms operate on (floored at OCCTSwift v1.12.9).
 - **Feeds:** downstream consumers of mesh post-processing — e.g. OCCTSwiftScripts' `simplify-mesh`
-  verb and OCCTMCP's `simplify_mesh` tool. Leaf with respect to other intra-org kernel libraries.
+  verb and OCCTMCP's `simplify_mesh` tool. The mesh foundations + segmentation layer is the common
+  upstream OCCTMCP's planned raw-mesh analysis tools (`segment_mesh_zones`, `zone_continuity_sweep`,
+  `mesh_diagnose`) and OCCTReconstruct are meant to consume, replacing per-consumer vendored
+  copies. Leaf with respect to other intra-org kernel libraries.
 
 ## Components
 
 See [`components/`](components/index.md) for the public surface (`Mesh.simplified(_:)`,
-`Mesh.crossSection(plane:)`, and the vendored meshoptimizer bridge).
+`Mesh.crossSection(plane:)`, the mesh connectivity/integrity toolkit, `Mesh.segmented(_:)`, and
+the vendored meshoptimizer bridge).
 
 ## References
 
-See [`references/`](references/index.md) for the decimation algorithm notes, vendored
-meshoptimizer upstream, and OpenCASCADE.
+See [`references/`](references/index.md) for the decimation, mesh-foundations, and segmentation
+algorithm notes, the OCCTReconstruct reference implementation, vendored meshoptimizer upstream,
+and OpenCASCADE.
 
 ## Notes
 

--- a/okf/references/index.md
+++ b/okf/references/index.md
@@ -11,11 +11,18 @@ timestamp: 2026-06-22
 
 - [docs/algorithms/decimation.md](https://github.com/SecondMouseAU/OCCTSwiftMesh/blob/main/docs/algorithms/decimation.md)
   — decimation algorithm notes.
+- [docs/algorithms/mesh-foundations.md](https://github.com/SecondMouseAU/OCCTSwiftMesh/blob/main/docs/algorithms/mesh-foundations.md)
+  — weld, connectivity toolkit, and integrity report notes.
+- [docs/algorithms/segmentation.md](https://github.com/SecondMouseAU/OCCTSwiftMesh/blob/main/docs/algorithms/segmentation.md)
+  — dihedral region-growing + primitive-fit merge notes.
 - [docs/VENDORING.md](https://github.com/SecondMouseAU/OCCTSwiftMesh/blob/main/docs/VENDORING.md)
   — how meshoptimizer is vendored and updated.
 - [docs/CHANGELOG.md](https://github.com/SecondMouseAU/OCCTSwiftMesh/blob/main/docs/CHANGELOG.md)
   — release history.
 - [meshoptimizer](https://github.com/zeux/meshoptimizer) — vendored upstream (MIT) powering the
   decimation path.
+- [OCCTReconstruct](https://github.com/SecondMouseAU/OCCTReconstruct) — source of the
+  `ReconstructCompute` reference implementation the mesh foundations and segmentation algorithms
+  were ported from.
 - [OpenCASCADE Technology (OCCT)](https://dev.opencascade.org/) — upstream B-Rep/mesh kernel the
   ecosystem wraps; OCCT meshes are the input to these algorithms.


### PR DESCRIPTION
## Summary

Closes #16, closes #17.

- **Mesh foundations** (#16): `Mesh.welded(tolerance:)`, `faceNormals()`, `vertexNormals()`, `triangleAdjacency()`, `connectedComponents()`, `subMesh(triangleIndices:)`, `boundaryLoops()`, `integrityReport() -> MeshIntegrityReport`.
- **Segmentation** (#17): `Mesh.segmented(_:) -> SegmentedMesh` — dihedral region-growing + a mandatory primitive-fit merge pass (`FittedPrimitive`: plane/cylinder/sphere/cone), undoing coarse-tessellation "confetti."
- Pure Swift + simd, no OCCT kernel calls. Ported from OCCTReconstruct's `ReconstructCompute` reference implementation (`IndexedMesh`, `RegionSegmentation`, `RegionMerging`, `PrimitiveFitting`, `Linalg`, plus `boundaryLoops`/`nonManifoldEdgeCount` from `MeshClosing`/`MeshRepair`), adapted to operate directly on `OCCTSwift.Mesh`'s own arrays instead of a separate `IndexedMesh` type.
- Version bumped 1.1.0 → 1.2.0.

Design notes and rationale: [`docs/algorithms/mesh-foundations.md`](../blob/feat/mesh-foundations-segmentation/docs/algorithms/mesh-foundations.md), [`docs/algorithms/segmentation.md`](../blob/feat/mesh-foundations-segmentation/docs/algorithms/segmentation.md). Full changelog in `docs/CHANGELOG.md`.

### Notable deviations from the reference implementation

- `triangleAdjacency`/`connectedComponents`/`boundaryLoops` require pre-welded input (documented precondition, matching the reference's own assumption); `integrityReport()` and `segmented(_:)` weld **internally** instead, specifically so unwelded input (raw OCCT tessellation, STL import) can't silently degrade to a meaningless result (one region/component per triangle).
- `segmented(_:)` computes adjacency/region-growing decisions from welded positions but fits primitives against the mesh's **original** (unwelded) geometry, for maximum fidelity.
- `PrimitiveFitter.bestFit` takes a precomputed `bodyDiag` instead of the reference's per-call bounds rescan (avoids an O(vertices) rescan on every candidate fit/merge — matters at the issue's stated 400k+ triangle scale).
- Added a cheap, fit-free coplanar pre-merge pass ahead of the fit-gated merge, gated on the same 1500-region cap the reference uses internally, per issue #17's explicit scale requirement.
- `SegmentOptions.maxRegions` / `minRegionTriangles` never truncate silently — `SegmentedMesh.truncatedTriangleCount` reports exactly what was dropped and why.

## Review

Three parallel adversarial review passes (port fidelity vs. the reference, edge-case/crash/Swift-6-concurrency hunting, and test-coverage-vs-issue-acceptance-criteria) surfaced four real, reproduced bugs, all now fixed with regression tests:

1. **Non-deterministic region composition** — `triangleAdjacency()` built each triangle's neighbour list from unsorted `Dictionary` iteration; order (not membership) varied between runs (Swift randomizes hash seeds per process), which leaked into segmentation's DFS and made `segmented(_:)` fail its own determinism test intermittently (~40–50% of runs). Fixed by sorting each adjacency list before returning.
2. **`Int64` overflow crash** in the weld grid-hash on degenerate (all-coincident-vertex) input combined with large coordinate magnitudes. Fixed by clamping the grid coordinate before conversion.
3. **Crash on negative `SegmentOptions.maxRegions`** (negative array slice bound). Fixed by clamping to zero.
4. **Wrong Euler characteristic / genus** when a dropped degenerate/duplicate triangle orphaned a welded vertex that `OCCTSwift.Mesh` never trims. Fixed by counting `V` from vertices actually referenced by the clean triangle list, not the full welded-position array.

## Test plan

- [x] `swift build` — clean, no warnings.
- [x] `swift test` — 53/53 passing (10 repeated full-suite runs, 15 repeated determinism-test-only runs, all clean — confirming the fixed flake doesn't recur).
- [x] Regression tests added for each of the four fixed bugs (huge-coincident-coordinate weld, orphaned-vertex Euler/genus, negative `maxRegions`, out-of-range `subMesh` indices).
- [x] Issue #16's required test list covered: weld idempotence, weld tolerance boundary, box adjacency/components, open (uncapped) cylinder shell (1 component, 2 boundary loops), a deliberately non-manifold fixture (both a non-manifold edge and a non-manifold/"bowtie" vertex, as separate fixtures), determinism.
- [x] Issue #17's required test list covered: box → 6 regions, 12-facet coarse capped cylinder → barrel + 2 caps (3 regions, the shatter regression), open (uncapped) cylinder shell → 1 merged cylinder region, determinism, explicit truncation reporting for both `maxRegions` and `minRegionTriangles`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
