### PR TITLE
fix: #19 review follow-ups — fitMergeSkipped, isWatertight, region-local fit floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ for (region, fit) in zip(segmented.regions, segmented.fits) {
     print(region.triangleIndices.count, "triangles →", fit.kind, fit.residualRMS)
 }
 // segmented.truncatedTriangleCount reports anything dropped by maxRegions / minRegionTriangles —
+// never silent. segmented.fitMergeSkipped reports when the fit-gated merge pass itself couldn't
+// run (raw region count still over an internal cap after the cheap coplanar pre-merge) — also
 // never silent.
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OCCTSwift itself stays focused on its mission as an OCCT wrapper. Mesh algorithm
 
 ## Status
 
-✅ **v1.2.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), and `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
+✅ **v1.3.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), and `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
 
 ## API
 

--- a/Sources/OCCTSwiftMesh/Mesh+Segmentation.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Segmentation.swift
@@ -49,7 +49,7 @@ extension Mesh {
             .map { MeshRegion(triangleIndices: $0, area: Mesh.area(ofTriangles: $0, vertices: verts, indices: idx)) }
             .sorted(by: MeshRegion.order)
 
-        let (mergedRegions, fits) = RegionMerging.merge(
+        let (mergedRegions, fits, fitMergeSkipped) = RegionMerging.merge(
             vertices: verts, indices: idx, regions: seeds, faceNormals: normals, adjacency: adjacency,
             bodyDiag: bodyDiag, relativeTolerance: options.mergeRelativeTolerance,
             maxMergeAngleDegrees: options.maxMergeAngleDegrees)
@@ -74,7 +74,8 @@ extension Mesh {
             }
         }
 
-        return SegmentedMesh(regions: filteredRegions, fits: filteredFits, truncatedTriangleCount: dropped)
+        return SegmentedMesh(regions: filteredRegions, fits: filteredFits, truncatedTriangleCount: dropped,
+                            fitMergeSkipped: fitMergeSkipped)
     }
 
     /// Deterministic DFS flood over edge-adjacent triangles, absorbing an unassigned neighbour
@@ -117,12 +118,16 @@ extension Mesh {
 /// Agglomerative region merging that repairs coarse-tessellation shattering.
 enum RegionMerging {
 
-    /// Merge regions by primitive fit. Returns the merged regions (largest-first) and each
-    /// merged region's best fit.
+    /// Merge regions by primitive fit. Returns the merged regions (largest-first), each merged
+    /// region's best fit, and whether the fit-gated pass itself ran at all — `fitMergeSkipped`
+    /// is `true` when even the coplanar pre-merge couldn't get the region count under
+    /// `maxRegionsToMerge`, in which case `regions`/`fits` are the pre-merge seed regions,
+    /// unmerged by primitive fit.
     static func merge(vertices: [SIMD3<Float>], indices: [UInt32], regions inputRegions: [MeshRegion],
                       faceNormals: [SIMD3<Float>], adjacency: [[Int]], bodyDiag: Double,
                       relativeTolerance: Double, maxMergeAngleDegrees: Float,
-                      maxRegionsToMerge: Int = 1500) -> (regions: [MeshRegion], fits: [FittedPrimitive]) {
+                      maxRegionsToMerge: Int = 1500)
+        -> (regions: [MeshRegion], fits: [FittedPrimitive], fitMergeSkipped: Bool) {
         var regions = inputRegions
         // Cheap coplanar pre-merge keeps the fit-gated pass below usable at 400k+ triangle
         // scans, where raw region counts can run into the thousands: a tight (~2°) coplanar
@@ -136,9 +141,11 @@ enum RegionMerging {
         guard n > 1, n <= maxRegionsToMerge else {
             let fits = regions.map {
                 PrimitiveFitter.bestFit(vertices: vertices, indices: indices, region: $0,
-                                       faceNormals: faceNormals, bodyDiag: bodyDiag)
+                                       faceNormals: faceNormals)
             }
-            return (regions, fits)
+            // n <= 1 (nothing left to merge) is not a skip — only report skipped when the
+            // fit-gated pass was bypassed because the region count is still over the cap.
+            return (regions, fits, n > maxRegionsToMerge)
         }
 
         let mergeTol = max(relativeTolerance * bodyDiag, 1e-6)
@@ -178,7 +185,7 @@ enum RegionMerging {
         var members = regions.map { $0.triangleIndices }
         var rootFit = regions.map {
             PrimitiveFitter.bestFit(vertices: vertices, indices: indices, region: $0,
-                                   faceNormals: faceNormals, bodyDiag: bodyDiag)
+                                   faceNormals: faceNormals)
         }
         func find(_ x: Int) -> Int { var r = x; while parent[r] != r { parent[r] = parent[parent[r]]; r = parent[r] }; return r }
 
@@ -193,7 +200,7 @@ enum RegionMerging {
                 let unionArea = Mesh.area(ofTriangles: union, vertices: vertices, indices: indices)
                 let fit = PrimitiveFitter.bestFit(vertices: vertices, indices: indices,
                                                  region: MeshRegion(triangleIndices: union, area: unionArea),
-                                                 faceNormals: faceNormals, bodyDiag: bodyDiag)
+                                                 faceNormals: faceNormals)
                 let separateBest = min(rootFit[a].residualRMS, rootFit[b].residualRMS)
                 guard fit.residualRMS <= mergeTol, fit.residualRMS <= separateBest + slack else { continue }
                 parent[b] = a
@@ -210,7 +217,7 @@ enum RegionMerging {
             pairs.append((MeshRegion(triangleIndices: members[r], area: area), rootFit[r]))
         }
         pairs.sort { MeshRegion.order($0.0, $1.0) }
-        return (pairs.map { $0.0 }, pairs.map { $0.1 })
+        return (pairs.map { $0.0 }, pairs.map { $0.1 }, false)
     }
 
     /// Cheap, fit-free pre-pass: union-find adjacent regions whose shared boundary is nearly

--- a/Sources/OCCTSwiftMesh/MeshIntegrityReport.swift
+++ b/Sources/OCCTSwiftMesh/MeshIntegrityReport.swift
@@ -25,7 +25,9 @@ public struct MeshIntegrityReport: Sendable {
     /// Every welded edge is shared by exactly two triangles (no boundary, no non-manifold
     /// edges), AND every vertex is manifold (no pinch points) — matching Open3D's
     /// `is_watertight`, which folds vertex-manifoldness in too (`nonManifoldVertexCount == 0`
-    /// is necessary, not just edge-manifoldness).
+    /// is necessary, not just edge-manifoldness) — minus Open3D's self-intersection clause:
+    /// this package doesn't detect self-intersections, so a self-intersecting closed manifold
+    /// still reports watertight here.
     public let isWatertight: Bool
     /// Every 2-triangle welded edge is traversed in opposite directions by its two triangles —
     /// a consistent winding exists. Only evaluated over 2-triangle edges; not meaningful when

--- a/Sources/OCCTSwiftMesh/MeshIntegrityReport.swift
+++ b/Sources/OCCTSwiftMesh/MeshIntegrityReport.swift
@@ -13,9 +13,19 @@ import Foundation
 import simd
 import OCCTSwift
 
+/// A triangle's welded, sorted vertex-index triple — an exact duplicate-face key at any mesh
+/// size, unlike a bit-packed integer key (which needs per-field bit budgets that cap the exact
+/// vertex-count range).
+private struct FaceKey: Hashable {
+    let a, b, c: UInt32
+}
+
 /// A mesh's manifoldness, validity, and quality snapshot.
 public struct MeshIntegrityReport: Sendable {
-    /// Every welded edge is shared by exactly two triangles (no boundary, no non-manifold edges).
+    /// Every welded edge is shared by exactly two triangles (no boundary, no non-manifold
+    /// edges), AND every vertex is manifold (no pinch points) — matching Open3D's
+    /// `is_watertight`, which folds vertex-manifoldness in too (`nonManifoldVertexCount == 0`
+    /// is necessary, not just edge-manifoldness).
     public let isWatertight: Bool
     /// Every 2-triangle welded edge is traversed in opposite directions by its two triangles —
     /// a consistent winding exists. Only evaluated over 2-triangle edges; not meaningful when
@@ -70,7 +80,7 @@ extension Mesh {
 
         var degenerateCount = 0
         var duplicateCount = 0
-        var seenFaces = Set<UInt64>()
+        var seenFaces = Set<FaceKey>()
         var cleanIndices: [UInt32] = []
         cleanIndices.reserveCapacity(idx0.count)
         for t in 0..<tc0 {
@@ -78,7 +88,7 @@ extension Mesh {
             let a = remap[Int(idx0[base])], b = remap[Int(idx0[base + 1])], c = remap[Int(idx0[base + 2])]
             if a == b || b == c || a == c { degenerateCount += 1; continue }
             let s = [a, b, c].sorted()
-            let key = (UInt64(s[0]) << 42) ^ (UInt64(s[1]) << 21) ^ UInt64(s[2])
+            let key = FaceKey(a: s[0], b: s[1], c: s[2])
             if !seenFaces.insert(key).inserted { duplicateCount += 1; continue }
             cleanIndices.append(a); cleanIndices.append(b); cleanIndices.append(c)
         }
@@ -115,7 +125,6 @@ extension Mesh {
         }
         let nonManifoldEdgeCount = edgeCount.values.filter { $0 >= 3 }.count
         let boundaryEdgeCount = edgeCount.values.filter { $0 == 1 }.count
-        let isWatertight = boundaryEdgeCount == 0 && nonManifoldEdgeCount == 0
 
         var isOrientable = true
         for (key, cnt) in edgeCount where cnt == 2 {
@@ -124,6 +133,9 @@ extension Mesh {
         }
 
         let nonManifoldVertexCount = Mesh.countNonManifoldVertices(indices: cIdx)
+        // Edge-manifold alone isn't enough: two closed shells pinched at one shared vertex have
+        // zero boundary/non-manifold EDGES but are not a single watertight fan at that vertex.
+        let isWatertight = boundaryEdgeCount == 0 && nonManifoldEdgeCount == 0 && nonManifoldVertexCount == 0
         let boundaryLoopCount = clean.boundaryLoops().count
         let components = clean.connectedComponents().map { (triangleCount: $0.triangleIndices.count, area: $0.area) }
 

--- a/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
+++ b/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
@@ -16,5 +16,5 @@
 /// to attach the module's documentation to.
 public enum OCCTSwiftMesh {
     /// Package version. Bump on each tagged release.
-    public static let version = "1.2.0"
+    public static let version = "1.3.0"
 }

--- a/Sources/OCCTSwiftMesh/PrimitiveFitter.swift
+++ b/Sources/OCCTSwiftMesh/PrimitiveFitter.swift
@@ -10,11 +10,9 @@ enum PrimitiveFitter {
 
     /// Fit the best primitive (lowest residual, with a simplicity bias toward planes) to a
     /// region. `vertices`/`indices` should be the mesh's ORIGINAL (unwelded) arrays — fitting
-    /// wants the truest available geometry, unperturbed by weld snapping. `bodyDiag` is the
-    /// whole mesh's bounding-box diagonal, precomputed once by the caller (fitting runs once
-    /// per candidate merge, so rescanning bounds per call would be quadratic at scale).
+    /// wants the truest available geometry, unperturbed by weld snapping.
     static func bestFit(vertices: [SIMD3<Float>], indices: [UInt32], region: MeshRegion,
-                        faceNormals: [SIMD3<Float>], bodyDiag: Double) -> FittedPrimitive {
+                        faceNormals: [SIMD3<Float>]) -> FittedPrimitive {
         let pts = regionPoints(vertices: vertices, indices: indices, region: region)
         let normals = region.triangleIndices.map { SIMD3<Double>(faceNormals[$0]) }
 
@@ -41,8 +39,14 @@ enum PrimitiveFitter {
         // primitive (plane > cylinder > cone > sphere) — this breaks ambiguous ties (e.g. a
         // short band a sphere also fits perfectly is really a cylinder). The absolute floor
         // matters: when the best fit is near-zero, a near-perfect cone must still count as
-        // "acceptable" against an exact sphere.
-        let absFloor = 1e-3 * bodyDiag
+        // "acceptable" against an exact sphere. Scaled by the REGION's own bounding-box
+        // diagonal, not the whole mesh's — a floor scaled by a large body would swamp a small,
+        // genuinely-curved region's tiny residual and misclassify a shallow arc as a plane
+        // (issue #20 item 4: a big flat body with an R5000-class, few-mm-sagitta roof).
+        var lo = pts.first ?? .zero, hi = pts.first ?? .zero
+        for p in pts { lo = simd_min(lo, p); hi = simd_max(hi, p) }
+        let regionDiag = simd_length(hi - lo)
+        let absFloor = 1e-3 * regionDiag
         let preference: [FittedPrimitive.Kind: Int] = [.plane: 0, .cylinder: 1, .cone: 2, .sphere: 3]
         let acceptable = candidates.filter { $0.residualRMS <= bestRMS * 1.25 + absFloor }
         return acceptable.min { (preference[$0.kind] ?? 9) < (preference[$1.kind] ?? 9) }!

--- a/Sources/OCCTSwiftMesh/SegmentedMesh.swift
+++ b/Sources/OCCTSwiftMesh/SegmentedMesh.swift
@@ -11,9 +11,18 @@ public struct SegmentedMesh: Sendable {
     /// `SegmentOptions.minRegionTriangles`. `0` when nothing was truncated.
     public let truncatedTriangleCount: Int
 
-    public init(regions: [MeshRegion], fits: [FittedPrimitive], truncatedTriangleCount: Int) {
+    /// `true` when the coplanar pre-merge alone couldn't get the raw region count under the
+    /// internal fit-gated-merge cap, so the primitive-fit merge pass was skipped entirely —
+    /// `regions`/`fits` are the UNMERGED seed regions from dihedral growing (plus coplanar
+    /// pre-merge), not the fully-merged result. Coarse-tessellation "confetti" will not have
+    /// been collapsed. `false` in the normal case where the fit-gated pass ran.
+    public let fitMergeSkipped: Bool
+
+    public init(regions: [MeshRegion], fits: [FittedPrimitive], truncatedTriangleCount: Int,
+                fitMergeSkipped: Bool = false) {
         self.regions = regions
         self.fits = fits
         self.truncatedTriangleCount = truncatedTriangleCount
+        self.fitMergeSkipped = fitMergeSkipped
     }
 }

--- a/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
@@ -165,3 +165,104 @@ func duplicateAndDegenerateFixture() -> Mesh {
     let indices: [UInt32] = [0, 1, 2, 0, 1, 2, 0, 3, 1]
     return Mesh(vertices: p, indices: indices)!
 }
+
+/// Two closed, watertight, orientable tetrahedra pinched together at exactly one shared vertex
+/// (a bowtie of closed shells, not just two open triangles) — every welded edge is still
+/// shared by exactly two triangles (no boundary, no non-manifold edge), so an edge-manifold-only
+/// watertight check reports this watertight; the shared apex is a non-manifold VERTEX (two
+/// disjoint triangle fans meeting at one point), which is the case `isWatertight` must catch.
+func bowtiePinchedClosedShellsFixture() -> Mesh {
+    let p: [SIMD3<Float>] = [
+        SIMD3(0, 0, 0),                                            // 0: shared apex
+        SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1),             // 1-3: shell A's other verts
+        SIMD3(10, 0, 0), SIMD3(0, 10, 0), SIMD3(0, 0, 10),          // 4-6: shell B's other verts
+    ]
+    let a: [UInt32] = [0, 2, 1, 0, 1, 3, 0, 3, 2, 1, 2, 3]
+    let b: [UInt32] = [0, 5, 4, 0, 4, 6, 0, 6, 5, 4, 5, 6]
+    return Mesh(vertices: p, indices: a + b)!
+}
+
+/// The same tetrahedron as `orientableTetrahedronMesh()`, but one face's winding is flipped —
+/// a shared edge is now traversed in the SAME direction by both its triangles instead of
+/// opposite directions, breaking the consistent orientation `isOrientable` checks for.
+func nonOrientableTetrahedronMesh() -> Mesh {
+    let p: [SIMD3<Float>] = [SIMD3(0, 0, 0), SIMD3(1, 0, 0), SIMD3(0, 1, 0), SIMD3(0, 0, 1)]
+    let indices: [UInt32] = [0, 2, 1, 0, 1, 3, 0, 2, 3, 1, 2, 3]   // 3rd face flipped: 0,3,2 -> 0,2,3
+    return Mesh(vertices: p, indices: indices)!
+}
+
+/// Duplicates every triangle's vertices into fresh, per-triangle-unique slots — the fully-
+/// unshared "soup" form raw OCCT tessellation / STL import produces. Geometrically identical to
+/// `mesh`; welding should collapse it back. A generic counterpart to `unweldedUnitCube()` for
+/// meshes built elsewhere (e.g. `coarseCappedCylinderMesh()`), for exercising the internal-weld
+/// path on a curved body, not just a box.
+func unwelded(_ mesh: Mesh) -> Mesh {
+    let verts = mesh.vertices
+    let idx = mesh.indices
+    var positions: [SIMD3<Float>] = []
+    var indices: [UInt32] = []
+    positions.reserveCapacity(idx.count)
+    indices.reserveCapacity(idx.count)
+    for i in idx {
+        indices.append(UInt32(positions.count))
+        positions.append(verts[Int(i)])
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A closed, watertight, orientable torus (genus 1) — a structured (major × minor) grid with
+/// both directions wrapped, triangulated with a uniform diagonal split per quad so winding stays
+/// consistent everywhere. Welded by construction (shared ring vertices).
+func torusMesh(majorRadius R: Float = 5, minorRadius r: Float = 1.5,
+               majorSegments: Int = 12, minorSegments: Int = 8) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    for i in 0..<majorSegments {
+        let u = Float(i) / Float(majorSegments) * 2 * .pi
+        for j in 0..<minorSegments {
+            let v = Float(j) / Float(minorSegments) * 2 * .pi
+            let x = (R + r * cos(v)) * cos(u)
+            let y = (R + r * cos(v)) * sin(u)
+            let z = r * sin(v)
+            positions.append(SIMD3(x, y, z))
+        }
+    }
+    func vertexIndex(_ i: Int, _ j: Int) -> UInt32 {
+        UInt32(((i + majorSegments) % majorSegments) * minorSegments + ((j + minorSegments) % minorSegments))
+    }
+    var indices: [UInt32] = []
+    for i in 0..<majorSegments {
+        for j in 0..<minorSegments {
+            let a = vertexIndex(i, j), b = vertexIndex(i + 1, j)
+            let c = vertexIndex(i, j + 1), d = vertexIndex(i + 1, j + 1)
+            indices.append(contentsOf: [a, b, d, a, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A shallow cylindrical arc strip — the kiha40-roof scenario from issue #20 item 4: a big
+/// radius (default 500) swept over a small angular span, so the surface deviates from its
+/// best-fit plane by only a modest sagitta relative to the strip's own footprint. Welded by
+/// construction (shared ring vertices), one connected patch.
+func shallowCylindricalArcMesh(radius: Float = 500, widthUnits: Float = 200, axialUnits: Float = 200,
+                               sides: Int = 10, rings: Int = 6) -> Mesh {
+    let angularSpan = widthUnits / radius
+    var positions: [SIMD3<Float>] = []
+    for k in 0..<rings {
+        let z = Float(k) / Float(rings - 1) * axialUnits
+        for i in 0..<sides {
+            let a = Float(i) / Float(sides - 1) * angularSpan
+            positions.append(SIMD3(radius * cos(a), radius * sin(a), z))
+        }
+    }
+    var indices: [UInt32] = []
+    for k in 0..<(rings - 1) {
+        let lo = UInt32(k * sides), hi = UInt32((k + 1) * sides)
+        for i in 0..<(sides - 1) {
+            let a = lo + UInt32(i), b = lo + UInt32(i + 1)
+            let c = hi + UInt32(i), d = hi + UInt32(i + 1)
+            indices.append(contentsOf: [a, b, c, b, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}

--- a/Tests/OCCTSwiftMeshTests/MeshFoundationsTests.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshFoundationsTests.swift
@@ -221,6 +221,36 @@ struct IntegrityReportTests {
         #expect(report.nonManifoldVertexCount == 1)
     }
 
+    @Test("Two closed shells pinched at one shared vertex are NOT watertight, despite every edge being manifold")
+    func pinchedClosedShellsAreNotWatertight() {
+        // Regression for issue #20 item 2: isWatertight must fold in vertex-manifoldness (per
+        // the cited Open3D convention) — an edge-manifold-only check would report this fixture
+        // watertight, since neither shell has a boundary or non-manifold edge.
+        let report = bowtiePinchedClosedShellsFixture().integrityReport()
+        #expect(report.nonManifoldEdgeCount == 0)
+        #expect(report.boundaryLoopCount == 0)
+        #expect(report.nonManifoldVertexCount == 1)
+        #expect(!report.isWatertight)
+    }
+
+    @Test("Inconsistent winding across a shared edge is reported as non-orientable")
+    func nonOrientableReport() {
+        let report = nonOrientableTetrahedronMesh().integrityReport()
+        #expect(report.isWatertight)
+        #expect(!report.isOrientable)
+        #expect(report.genus == nil)
+    }
+
+    @Test("A torus (genus 1) reports Euler characteristic 0 and genus 1")
+    func torusReport() {
+        let report = torusMesh().integrityReport()
+        #expect(report.isWatertight)
+        #expect(report.isOrientable)
+        #expect(report.eulerCharacteristic == 0)
+        #expect(report.genus == 1)
+        #expect(report.components.count == 1)
+    }
+
     @Test("Duplicate and degenerate triangles are counted from the raw topology")
     func duplicateAndDegenerateReport() {
         let report = duplicateAndDegenerateFixture().integrityReport()

--- a/Tests/OCCTSwiftMeshTests/MeshSegmentationTests.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshSegmentationTests.swift
@@ -27,6 +27,17 @@ struct SegmentationTests {
         for region in result.regions { #expect(region.triangleIndices.count == 2) }
     }
 
+    @Test("Unwelded curved body still merges its shattered barrel — internal weld path holds beyond the box case")
+    func unweldedCurvedBodyStillSegments() {
+        let mesh = unwelded(coarseCappedCylinderMesh(radius: 4, sides: 12, rings: 5, height: 4))
+        let result = mesh.segmented()
+        #expect(result.regions.count == 3)
+        let cylinders = result.fits.filter { $0.kind == .cylinder }
+        let planes = result.fits.filter { $0.kind == .plane }
+        #expect(cylinders.count == 1)
+        #expect(planes.count == 2)
+    }
+
     @Test("A coarse capped cylinder merges its shattered barrel facets back into one cylinder")
     func coarseCylinderMergesToBarrelPlusCaps() {
         let mesh = coarseCappedCylinderMesh(radius: 4, sides: 12, rings: 5, height: 4)
@@ -105,5 +116,68 @@ struct SegmentationTests {
         #expect(result.regions.isEmpty)
         #expect(result.fits.isEmpty)
         #expect(result.truncatedTriangleCount == 12)
+    }
+
+    @Test("The normal (under-cap) path never reports the fit-gated merge pass as skipped")
+    func fitMergeNotSkippedInNormalPath() {
+        #expect(!weldedUnitCube().segmented().fitMergeSkipped)
+    }
+}
+
+@Suite("RegionMerging.merge — fit-merge-skipped diagnostic (issue #20 item 1)")
+struct FitMergeSkippedTests {
+    @Test("When even the coplanar pre-merge can't get under the cap, the fit-gated pass is skipped and reported")
+    func skipIsReportedWhenCapExceeded() {
+        let mesh = weldedUnitCube()
+        let normals = mesh.faceNormals()
+        let adjacency = mesh.triangleAdjacency()
+        let seeds = Mesh.segmentSmoothRegions(triangleCount: mesh.triangleCount, normals: normals,
+                                              adjacency: adjacency, maxDihedralDegrees: 20)
+            .map { MeshRegion(triangleIndices: $0,
+                              area: Mesh.area(ofTriangles: $0, vertices: mesh.vertices, indices: mesh.indices)) }
+        // 6 box faces, 90° apart — the ~2° coplanar pre-merge can't touch them, so the region
+        // count stays at 6, above the artificially tiny cap below.
+        #expect(seeds.count == 6)
+
+        var lo = mesh.vertices[0], hi = mesh.vertices[0]
+        for p in mesh.vertices { lo = simd_min(lo, p); hi = simd_max(hi, p) }
+        let bodyDiag = Double(simd_length(hi - lo))
+
+        let (regions, fits, skipped) = RegionMerging.merge(
+            vertices: mesh.vertices, indices: mesh.indices, regions: seeds, faceNormals: normals,
+            adjacency: adjacency, bodyDiag: bodyDiag, relativeTolerance: 0.004, maxMergeAngleDegrees: 50,
+            maxRegionsToMerge: 3)
+        #expect(skipped)
+        #expect(regions.count == 6)   // unmerged seed regions — the fit-gated pass never ran
+        #expect(fits.count == 6)
+    }
+
+    @Test("A single region (nothing to merge) is not reported as skipped")
+    func singleRegionIsNotSkipped() {
+        let mesh = weldedUnitCube()
+        let region = MeshRegion(triangleIndices: Array(0..<mesh.triangleCount),
+                                area: Mesh.area(ofTriangles: Array(0..<mesh.triangleCount),
+                                                vertices: mesh.vertices, indices: mesh.indices))
+        let normals = mesh.faceNormals()
+        let adjacency = mesh.triangleAdjacency()
+        let (_, _, skipped) = RegionMerging.merge(
+            vertices: mesh.vertices, indices: mesh.indices, regions: [region], faceNormals: normals,
+            adjacency: adjacency, bodyDiag: 1, relativeTolerance: 0.004, maxMergeAngleDegrees: 50)
+        #expect(!skipped)
+    }
+}
+
+@Suite("PrimitiveFitter.bestFit — region-local floor (issue #20 item 4)")
+struct PrimitiveFitterFloorTests {
+    @Test("A shallow cylindrical arc classifies as a cylinder via a region-local tie-break floor")
+    func shallowArcClassifiesAsCylinder() {
+        let mesh = shallowCylindricalArcMesh(radius: 500, widthUnits: 200, axialUnits: 200)
+        let allTriangles = Array(0..<mesh.triangleCount)
+        let region = MeshRegion(triangleIndices: allTriangles,
+                                area: Mesh.area(ofTriangles: allTriangles, vertices: mesh.vertices, indices: mesh.indices))
+        let fit = PrimitiveFitter.bestFit(vertices: mesh.vertices, indices: mesh.indices, region: region,
+                                          faceNormals: mesh.faceNormals())
+        #expect(fit.kind == .cylinder)
+        if let radius = fit.radius { #expect(abs(radius - 500) < 5) }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to OCCTSwiftMesh.
 
+## Unreleased
+
+Follow-ups from the v1.2.0 (#19) review, tracked in [#20](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/20). None affect the correctness of what shipped in v1.2.0; two are behavior fixes, the rest are diagnostics/docs/tests.
+
+- **`SegmentedMesh.fitMergeSkipped: Bool`** (new field) — `true` when even the coplanar
+  pre-merge couldn't get the raw region count under the internal 1500-region cap, so the
+  fit-gated merge pass was skipped entirely; `regions`/`fits` are then the unmerged seed regions.
+  Previously silent — the caller saw thousands of "confetti" regions with no indication why.
+- **`MeshIntegrityReport.isWatertight` now folds in vertex-manifoldness** (behavior fix):
+  requires `nonManifoldVertexCount == 0` in addition to zero boundary/non-manifold edges, matching
+  Open3D's actual `is_watertight` definition. Previously, two closed shells pinched at one shared
+  vertex (a bowtie of closed shells) reported watertight, since neither shell has a boundary or
+  non-manifold edge.
+- **`integrityReport()`'s duplicate-face key is now exact at any welded-vertex count** — replaced
+  a bit-packed `UInt64` key (three 21-bit fields, exact only below ~2M welded vertices) with a
+  3-field `UInt32` struct key.
+- **`PrimitiveFitter.bestFit`'s fit-kind tie-break floor now scales with the REGION's own
+  bounding-box diagonal, not the whole mesh's** (behavior fix, `bodyDiag` dropped from `bestFit`'s
+  signature) — a body-wide floor could swamp a small, genuinely-curved region's tiny residual on
+  a much larger body (an R5000-class, few-mm-sagitta roof panel on a multi-metre body), reporting
+  `fit.kind == .plane` where the surface was really a shallow arc. Region membership was never
+  affected; only the reported `fit.kind` on the affected region.
+- `docs/algorithms/segmentation.md` now documents that `segmented(_:)`, unlike `welded(_:)`, does
+  not drop triangles that degenerate as a result of the internal weld (mitigated by
+  `SegmentOptions.minRegionTriangles`).
+- New test fixtures/coverage: an inconsistent-winding (`isOrientable == false`) fixture, a torus
+  (genus 1) fixture, and an unwelded curved-body segmentation case (previously only the box was
+  tested unwelded).
+
 ## v1.2.0 — mesh foundations + region segmentation
 
 Adds the mesh connectivity toolkit ([#16](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/16))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to OCCTSwiftMesh.
 
-## Unreleased
+## v1.3.0 — #19 review follow-ups (fitMergeSkipped, isWatertight, region-local fit floor)
 
 Follow-ups from the v1.2.0 (#19) review, tracked in [#20](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/20). None affect the correctness of what shipped in v1.2.0; two are behavior fixes, the rest are diagnostics/docs/tests.
 

--- a/docs/algorithms/mesh-foundations.md
+++ b/docs/algorithms/mesh-foundations.md
@@ -50,6 +50,10 @@ on the deduplicated, non-degenerate topology instead, so a handful of exact dupl
 doesn't masquerade as a real non-manifold defect (a duplicated triangle trivially makes its three
 edges non-manifold — that's noise, not signal).
 
+The duplicate-face check keys each triangle on its sorted, welded vertex-index triple (three
+`UInt32`s) rather than bit-packing them into one integer — exact at any welded-vertex count,
+with no field-width ceiling to document or hit.
+
 Semantics follow the [Open3D `TriangleMesh`](https://www.open3d.org/docs/release/tutorial/geometry/mesh.html)
 conventions (`is_edge_manifold` / `is_vertex_manifold` / `is_watertight` /
 `cluster_connected_triangles`) — the cleanest in the field per the tracking issue.
@@ -63,6 +67,16 @@ branch point (an opposite-edge endpoint touched by 3+ opposite edges) or a secon
 chain (a pinch point / bowtie, two cones of triangles touching at exactly one vertex) makes `v`
 non-manifold. Implemented by building the per-vertex "opposite edge" graph and checking max
 degree ≤ 2 and exactly one connected component.
+
+### `isWatertight` folds in vertex-manifoldness
+
+`isWatertight` requires `nonManifoldVertexCount == 0` in addition to zero boundary and zero
+non-manifold edges — matching Open3D's actual `is_watertight` definition (edge-manifold AND
+vertex-manifold AND no boundary), not just the edge-manifold half of it. Edge-manifoldness alone
+misses a real defect: two otherwise-closed shells pinched together at a single shared vertex (a
+"bowtie" of closed shells) have zero boundary edges and zero non-manifold edges — every edge is
+still shared by exactly two triangles — but the pinch vertex is not a single triangle fan, so the
+result is not a single watertight solid.
 
 ### Genus
 

--- a/docs/algorithms/mesh-foundations.md
+++ b/docs/algorithms/mesh-foundations.md
@@ -72,7 +72,9 @@ degree ≤ 2 and exactly one connected component.
 
 `isWatertight` requires `nonManifoldVertexCount == 0` in addition to zero boundary and zero
 non-manifold edges — matching Open3D's actual `is_watertight` definition (edge-manifold AND
-vertex-manifold AND no boundary), not just the edge-manifold half of it. Edge-manifoldness alone
+vertex-manifold AND no boundary), not just the edge-manifold half of it — with one caveat:
+Open3D's check also excludes self-intersecting meshes, and this package doesn't detect
+self-intersection, so a self-intersecting closed manifold still reports watertight here. Edge-manifoldness alone
 misses a real defect: two otherwise-closed shells pinched together at a single shared vertex (a
 "bowtie" of closed shells) have zero boundary edges and zero non-manifold edges — every edge is
 still shared by exactly two triangles — but the pinch vertex is not a single triangle fan, so the

--- a/docs/algorithms/segmentation.md
+++ b/docs/algorithms/segmentation.md
@@ -31,15 +31,29 @@ This is why unwelded input does NOT silently degrade to one region per triangle 
 mode the tracking issue explicitly calls out): adjacency is always computed on welded topology
 regardless of whether the input `Mesh` itself was pre-welded.
 
-## Performance: `bestFit`'s `bodyDiag` is hoisted, not recomputed
+**Unlike `welded(tolerance:)`, `segmented(_:)` does not drop triangles that degenerate (repeat a
+vertex) as a result of the internal weld.** A degenerate triangle still gets a face normal (the
++Z fallback — see `faceNormals()`) and still participates in region-growing / merging like any
+other triangle. On dirty scans this can surface as junk single-triangle regions; the existing
+`SegmentOptions.minRegionTriangles` filter is the mitigation (raise it above 1 to drop them).
 
-The OCCTReconstruct reference recomputes the mesh's bounding-box diagonal inside every
-`PrimitiveFitter.bestFit` call (used for an absolute residual floor). `bestFit` is called once
-per candidate region AND once per candidate merge during the fit-gated pass — recomputing an
-O(vertices) bounds scan on every one of those calls is quadratic-ish at scale. This port hoists
-`bodyDiag` to a single computation in `segmented(_:)`, threaded through as a parameter — the
-same math, computed once. Given the tracking issue's explicit "usable at 400k+ triangles"
-requirement, this isn't optional polish.
+## Performance: `bodyDiag` is hoisted, not recomputed
+
+The OCCTReconstruct reference recomputes the mesh's bounding-box diagonal on every relevant
+call site (used to scale the merge-acceptance tolerance). Doing that on every candidate merge
+during the fit-gated pass would be an O(vertices) bounds scan per call — quadratic-ish at scale.
+This port hoists `bodyDiag` to a single computation in `segmented(_:)`, threaded through
+`RegionMerging.merge` as a parameter for `mergeTol` — the same math, computed once. Given the
+tracking issue's explicit "usable at 400k+ triangles" requirement, this isn't optional polish.
+
+`PrimitiveFitter.bestFit`'s own absolute residual floor (the fit-KIND tie-break, not the merge
+gate above) does NOT use `bodyDiag` — it scales off the REGION's own bounding-box diagonal,
+computed from the region's points directly inside `bestFit`. A body-wide floor was too coarse: a
+shallow, genuinely-curved region on a much larger flat body (issue #20 item 4 — an R5000-class,
+few-mm-sagitta roof panel on a multi-metre body) had its tiny residual swamped by a floor scaled
+to the whole body, so `fit.kind` read `plane` where the surface was really a shallow arc. Region
+MEMBERSHIP was never affected by this (the merge gate above uses residual RMS against `mergeTol`
+only) — only the reported `fit.kind` on the affected region.
 
 ## Scale: coplanar pre-merge before the fit-gated pass
 
@@ -60,6 +74,12 @@ after each merge).
 `SegmentedMesh.truncatedTriangleCount`, rather than silently shrinking the result. This mirrors
 the tracking issue's explicit requirement — a cap that silently drops coverage reads as "fully
 segmented" when it wasn't.
+
+The same ethos applies to the fit-gated merge pass itself: if the coplanar pre-merge can't get
+the raw region count under the internal 1500-region cap, the fit-gated pass is skipped entirely
+rather than silently returning thousands of unmerged confetti regions with no explanation.
+`SegmentedMesh.fitMergeSkipped` reports exactly that — `true` means `regions`/`fits` are the
+pre-merge seed regions, not the fully-merged result.
 
 ## Determinism
 


### PR DESCRIPTION
Closes #20 — the six non-blocking follow-ups from the v1.2.0 (#19) review. None affect the correctness of what shipped in v1.2.0; two are behavior fixes, the rest are diagnostics/docs/tests.

## Changes

1. **`SegmentedMesh.fitMergeSkipped: Bool`** (new field) — `true` when even the coplanar pre-merge couldn't get the raw region count under the internal 1500-region cap, so the fit-gated merge pass was skipped entirely. Previously silent: the caller saw thousands of "confetti" regions with no indication why.
2. **`MeshIntegrityReport.isWatertight` now folds in vertex-manifoldness** (behavior fix) — requires `nonManifoldVertexCount == 0` in addition to zero boundary/non-manifold edges, matching Open3D's actual `is_watertight` definition rather than just its edge-manifold half. Previously, two closed shells pinched at one shared vertex reported watertight.
3. **`integrityReport()`'s duplicate-face key is now exact at any welded-vertex count** — replaced a bit-packed `UInt64` key (three 21-bit fields, exact only below ~2M welded vertices) with a 3-field `UInt32` struct key.
4. **`PrimitiveFitter.bestFit`'s fit-kind tie-break floor now scales with the region's own bounding-box diagonal, not the whole mesh's** (behavior fix, `bodyDiag` dropped from `bestFit`'s signature) — a body-wide floor could swamp a small, genuinely-curved region's tiny residual on a much larger body (an R5000-class, few-mm-sagitta roof panel on a multi-metre body), misreporting `fit.kind == .plane`. Region membership was never affected, only the reported kind.
5. `docs/algorithms/segmentation.md` now documents that `segmented(_:)`, unlike `welded(_:)`, doesn't drop triangles that degenerate as a result of the internal weld (mitigated by `SegmentOptions.minRegionTriangles`).
6. New test fixtures/coverage: an inconsistent-winding (`isOrientable == false`) fixture, a torus (genus 1) fixture, and an unwelded curved-body segmentation case (previously only the box was tested unwelded).

Docs (`mesh-foundations.md`, `segmentation.md`), `README.md`, and `docs/CHANGELOG.md` (new "Unreleased" section) are all updated to match.

## Test plan

- [x] `swift build` clean, no warnings
- [x] `swift test` — 61/61 passing, including 8 new tests covering items 1, 2, 4, and 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)