### PR TITLE
Discrete curvature estimation — Mesh.vertexCurvatures() — v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OCCTSwift itself stays focused on its mission as an OCCT wrapper. Mesh algorithm
 
 ## Status
 
-✅ **v1.3.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), and `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
+✅ **v1.4.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge), and `Mesh.vertexCurvatures()` (Rusinkiewicz per-face curvature tensor). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
 
 ## API
 
@@ -103,6 +103,24 @@ for (region, fit) in zip(segmented.regions, segmented.fits) {
 // never silent. segmented.fitMergeSkipped reports when the fit-gated merge pass itself couldn't
 // run (raw region count still over an internal cap after the cheap coplanar pre-merge) — also
 // never silent.
+```
+
+### Curvature — `Mesh.vertexCurvatures()`
+
+Per-vertex principal curvatures and directions (Rusinkiewicz per-face tensor method, chosen over
+Meyer's cotan-Laplacian for robustness on noisy/irregular tessellation — no obtuse-triangle
+clamp anywhere in the pipeline). Requires welded input, same precondition as `triangleAdjacency()`
+/`connectedComponents()`.
+
+```swift
+let welded = mesh.welded()
+for c in welded.vertexCurvatures() {
+    print(c.k1, c.k2, c.mean, c.gaussian)  // c.d1/c.d2 — unit principal directions
+}
+// k1 is signed positive for a convex bulge (e.g. an outward-facing sphere), matching
+// vertexNormals()'s own outward-normal convention. A face too degenerate/sliver-thin for a
+// stable fit is excluded from it entirely; a vertex touched only by such faces reports
+// k1 == k2 == 0, never NaN.
 ```
 
 ## Installation

--- a/Sources/OCCTSwiftMesh/Mesh+Curvature.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Curvature.swift
@@ -1,0 +1,211 @@
+// Mesh+Curvature.swift — Rusinkiewicz per-face curvature tensor, averaged onto vertices.
+//
+// Ported from the algorithm in Rusinkiewicz, "Estimating Curvatures and Their Derivatives on
+// Triangle Meshes" (3DPVT 2004) — the same method trimesh2's TriMesh_curvature.cc (MIT) and the
+// PMP library's curvature module implement. Chosen over Meyer et al.'s cotan-Laplacian approach
+// specifically for robustness on noisy/irregular real-scan tessellation: this method fits a
+// curvature tensor directly from each face's edge vectors and vertex-normal differences, with no
+// obtuse-triangle clamp anywhere in the pipeline (the cotan approach needs one, and still
+// degrades on slivers).
+//
+// Requires WELDED input, same precondition as `triangleAdjacency()`/`connectedComponents()` (see
+// Mesh+Topology.swift's file header) — per-face tensors are averaged onto each vertex over every
+// triangle sharing that vertex's WELDED index; on unwelded input every vertex touches exactly one
+// triangle, so the result is just that triangle's own (unaveraged, and for a single flat triangle,
+// zero) curvature repeated per corner.
+
+import simd
+import OCCTSwift
+
+extension Mesh {
+
+    /// Per-vertex principal curvatures and directions (see `VertexCurvature`).
+    ///
+    /// Requires a WELDED mesh — see the file header. Degenerate (near-zero-area) triangles are
+    /// excluded from the fit entirely rather than propagating garbage: a face whose fit is
+    /// singular, or whose contribution weight (area) is negligible, simply contributes nothing
+    /// to its corners' averages. A vertex touched only by such faces (or by none at all) reports
+    /// `k1 == k2 == 0`, never `NaN`.
+    public func vertexCurvatures() -> [VertexCurvature] {
+        let verts = vertices
+        let idx = indices
+        let tc = triangleCount
+        let n = verts.count
+        guard n > 0, tc > 0 else { return [] }
+
+        let normalsF = vertexNormals()
+        let normals = normalsF.map { SIMD3<Double>($0) }
+
+        // Initial per-vertex tangent basis: an arbitrary but deterministic incident edge
+        // (last-writer-wins over faces in triangle-index order, which is itself deterministic),
+        // projected orthogonal to the vertex normal. Only used as bookkeeping for accumulating a
+        // symmetric tensor per vertex — the final principal directions/curvatures (after
+        // diagonalization) are independent of this initial choice.
+        var pdir1 = [SIMD3<Double>](repeating: .zero, count: n)
+        for t in 0..<tc {
+            let base = t * 3
+            let ia = Int(idx[base]), ib = Int(idx[base + 1]), ic = Int(idx[base + 2])
+            let a = SIMD3<Double>(verts[ia]), b = SIMD3<Double>(verts[ib]), c = SIMD3<Double>(verts[ic])
+            pdir1[ia] = b - a
+            pdir1[ib] = c - b
+            pdir1[ic] = a - c
+        }
+        for i in 0..<n {
+            let nrm = normals[i]
+            var p = simd_cross(pdir1[i], nrm)
+            let len = simd_length(p)
+            if len > 1e-12 {
+                p /= len
+            } else {
+                let helper = abs(nrm.x) < 0.9 ? SIMD3<Double>(1, 0, 0) : SIMD3<Double>(0, 1, 0)
+                p = simd_normalize(simd_cross(nrm, helper))
+            }
+            pdir1[i] = p
+        }
+        var pdir2 = [SIMD3<Double>](repeating: .zero, count: n)
+        for i in 0..<n { pdir2[i] = simd_cross(normals[i], pdir1[i]) }
+
+        var curv1 = [Double](repeating: 0, count: n)
+        var curv12 = [Double](repeating: 0, count: n)
+        var curv2 = [Double](repeating: 0, count: n)
+        var weightSum = [Double](repeating: 0, count: n)
+
+        for t in 0..<tc {
+            let base = t * 3
+            let vi = (Int(idx[base]), Int(idx[base + 1]), Int(idx[base + 2]))
+            let p0 = SIMD3<Double>(verts[vi.0]), p1 = SIMD3<Double>(verts[vi.1]), p2 = SIMD3<Double>(verts[vi.2])
+            // e[j] is the edge OPPOSITE vertex j.
+            let e = (p2 - p1, p0 - p2, p1 - p0)
+            let faceNormalUnnormalized = simd_cross(e.0, e.1)
+            let twiceArea = simd_length(faceNormalUnnormalized)
+            let longestEdge = max(simd_length(e.0), max(simd_length(e.1), simd_length(e.2)))
+            // Sliver-robust: exclude degenerate/zero-area faces AND extreme slivers (area tiny
+            // relative to the longest edge squared, i.e. a near-zero minimum angle) from the fit
+            // entirely, rather than feeding an ill-conditioned edge/normal-difference system that
+            // could solve to a huge (if still technically finite) garbage tensor. A documented
+            // degradation — the sliver's own corners simply don't get this face's contribution —
+            // rather than poisoning them with an unstable fit.
+            guard longestEdge > 1e-15, twiceArea > 2e-4 * longestEdge * longestEdge else { continue }
+            let tTang = e.0 / simd_length(e.0)
+            let bTang = simd_normalize(simd_cross(faceNormalUnnormalized, tTang))
+            guard tTang.x.isFinite, bTang.x.isFinite else { continue }
+
+            let vn = (normals[vi.0], normals[vi.1], normals[vi.2])
+            let edges = [e.0, e.1, e.2]
+
+            var w00 = 0.0, w01 = 0.0, w22 = 0.0
+            var m0 = 0.0, m1 = 0.0, m2 = 0.0
+            for j in 0..<3 {
+                let u = simd_dot(edges[j], tTang)
+                let v = simd_dot(edges[j], bTang)
+                w00 += u * u; w01 += u * v; w22 += v * v
+                let vnPrev = j == 0 ? vn.2 : (j == 1 ? vn.0 : vn.1)   // (j+2)%3
+                let vnNext = j == 0 ? vn.1 : (j == 1 ? vn.2 : vn.0)   // (j+1)%3
+                let dn = vnPrev - vnNext
+                let dnu = simd_dot(dn, tTang), dnv = simd_dot(dn, bTang)
+                m0 += dnu * u; m1 += dnu * v + dnv * u; m2 += dnv * v
+            }
+            let w11 = w00 + w22
+            let system: [[Double]] = [[w00, w01, 0], [w01, w11, w01], [0, w01, w22]]
+            guard let sol = Linalg.solve(system, [m0, m1, m2]) else { continue }   // singular: skip
+            let (eVal, fVal, gVal) = (sol[0], sol[1], sol[2])
+            guard eVal.isFinite, fVal.isFinite, gVal.isFinite else { continue }
+
+            let area = Double(twiceArea) * 0.5
+            let corners = [vi.0, vi.1, vi.2]
+            for vIdx in corners {
+                let (ku, kuv, kv) = Mesh.projCurv(
+                    oldU: tTang, oldV: bTang, oldKu: eVal, oldKuv: fVal, oldKv: gVal,
+                    newU: pdir1[vIdx], newV: pdir2[vIdx])
+                curv1[vIdx] += area * ku
+                curv12[vIdx] += area * kuv
+                curv2[vIdx] += area * kv
+                weightSum[vIdx] += area
+            }
+        }
+
+        var result = [VertexCurvature]()
+        result.reserveCapacity(n)
+        for i in 0..<n {
+            let w = weightSum[i]
+            guard w > 1e-15 else {
+                result.append(VertexCurvature(k1: 0, k2: 0, d1: SIMD3<Float>(pdir1[i]), d2: SIMD3<Float>(pdir2[i])))
+                continue
+            }
+            let ku = curv1[i] / w, kuv = curv12[i] / w, kv = curv2[i] / w
+            let (pd1, pd2, k1, k2) = Mesh.diagonalizeCurv(
+                oldU: pdir1[i], oldV: pdir2[i], ku: ku, kuv: kuv, kv: kv, newNorm: normals[i])
+            if k1.isFinite, k2.isFinite, pd1.x.isFinite, pd2.x.isFinite {
+                result.append(VertexCurvature(k1: k1, k2: k2, d1: SIMD3<Float>(pd1), d2: SIMD3<Float>(pd2)))
+            } else {
+                result.append(VertexCurvature(k1: 0, k2: 0, d1: SIMD3<Float>(pdir1[i]), d2: SIMD3<Float>(pdir2[i])))
+            }
+        }
+        return result
+    }
+
+    // MARK: - Curvature-tensor rotation helpers (Rusinkiewicz 2004 / trimesh2)
+
+    /// Rotate the tangent basis `(oldU, oldV)` so it's perpendicular to `newNorm` instead of its
+    /// own implied normal `cross(oldU, oldV)`, via the minimal rotation that takes one normal to
+    /// the other (exact for any pair of unit normals, not just nearby ones).
+    static func rotCoordSys(oldU: SIMD3<Double>, oldV: SIMD3<Double>, newNorm: SIMD3<Double>)
+        -> (SIMD3<Double>, SIMD3<Double>) {
+        var newU = oldU
+        var newV = oldV
+        let oldNorm = simd_cross(oldU, oldV)
+        let ndot = simd_dot(oldNorm, newNorm)
+        // Antipodal (or numerically indistinguishable from it): rotating would divide by ~0 in
+        // `dperp` below, so just flip instead of computing a blown-up correction.
+        guard ndot > -1 + 1e-6 else { return (-newU, -newV) }
+        let perpOld = newNorm - ndot * oldNorm
+        let dperp = (1.0 / (1.0 + ndot)) * (oldNorm + newNorm)
+        newU -= dperp * simd_dot(perpOld, newU)
+        newV -= dperp * simd_dot(perpOld, newV)
+        return (newU, newV)
+    }
+
+    /// Re-express a curvature tensor given in the `(oldU, oldV)` basis (as `[[oldKu, oldKuv],
+    /// [oldKuv, oldKv]]`) in the `(newU, newV)` basis instead — `newU`/`newV` need not be exactly
+    /// tangent to the same surface point; `rotCoordSys` reconciles the small normal mismatch.
+    static func projCurv(oldU: SIMD3<Double>, oldV: SIMD3<Double>, oldKu: Double, oldKuv: Double, oldKv: Double,
+                         newU: SIMD3<Double>, newV: SIMD3<Double>) -> (Double, Double, Double) {
+        let oldNorm = simd_cross(oldU, oldV)
+        let (rNewU, rNewV) = rotCoordSys(oldU: newU, oldV: newV, newNorm: oldNorm)
+        let u1 = simd_dot(rNewU, oldU), v1 = simd_dot(rNewU, oldV)
+        let u2 = simd_dot(rNewV, oldU), v2 = simd_dot(rNewV, oldV)
+        let newKu = oldKu * u1 * u1 + oldKuv * (2 * u1 * v1) + oldKv * v1 * v1
+        let newKuv = oldKu * u1 * u2 + oldKuv * (u1 * v2 + u2 * v1) + oldKv * v1 * v2
+        let newKv = oldKu * u2 * u2 + oldKuv * (2 * u2 * v2) + oldKv * v2 * v2
+        return (newKu, newKuv, newKv)
+    }
+
+    /// Diagonalize a vertex's accumulated curvature tensor (given in its own `(oldU, oldV)`
+    /// basis) into principal curvatures/directions. `k1` is always the eigenvalue of larger
+    /// magnitude; `pdir2` is always `cross(newNorm, pdir1)`.
+    static func diagonalizeCurv(oldU: SIMD3<Double>, oldV: SIMD3<Double>, ku: Double, kuv: Double, kv: Double,
+                                newNorm: SIMD3<Double>) -> (pdir1: SIMD3<Double>, pdir2: SIMD3<Double>, k1: Double, k2: Double) {
+        let (rOldU, rOldV) = rotCoordSys(oldU: oldU, oldV: oldV, newNorm: newNorm)
+
+        var c = 1.0, s = 0.0, tt = 0.0
+        if kuv != 0 {
+            let h = 0.5 * (kv - ku) / kuv
+            tt = 1.0 / (abs(h) + (h * h + 1).squareRoot())
+            if h < 0 { tt = -tt }
+            c = 1.0 / (tt * tt + 1).squareRoot()
+            s = tt * c
+        }
+        var k1 = ku - tt * kuv
+        var k2 = kv + tt * kuv
+
+        let pdir1: SIMD3<Double>
+        if abs(k1) >= abs(k2) {
+            pdir1 = c * rOldU - s * rOldV
+        } else {
+            swap(&k1, &k2)
+            pdir1 = s * rOldU + c * rOldV
+        }
+        let pdir2 = simd_cross(newNorm, pdir1)
+        return (pdir1, pdir2, k1, k2)
+    }
+}

--- a/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
+++ b/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
@@ -8,6 +8,8 @@
 //   .integrityReport() — the mesh connectivity toolkit and quality/validity snapshot.
 // Mesh.segmented(_:) — dihedral region-growing + primitive-fit merge, splitting a mesh
 //   into plane/cylinder/sphere/cone surface regions.
+// Mesh.vertexCurvatures() — per-vertex principal curvatures/directions (Rusinkiewicz
+//   per-face tensor method).
 // See docs/CHANGELOG.md and docs/algorithms/.
 
 /// Namespace marker for the OCCTSwiftMesh module. The public surface lives
@@ -16,5 +18,5 @@
 /// to attach the module's documentation to.
 public enum OCCTSwiftMesh {
     /// Package version. Bump on each tagged release.
-    public static let version = "1.3.0"
+    public static let version = "1.4.0"
 }

--- a/Sources/OCCTSwiftMesh/VertexCurvature.swift
+++ b/Sources/OCCTSwiftMesh/VertexCurvature.swift
@@ -1,0 +1,33 @@
+// VertexCurvature.swift — the per-vertex differential-geometry summary produced by
+// `Mesh.vertexCurvatures()`.
+
+import simd
+
+/// Principal curvatures and directions estimated at one mesh vertex.
+///
+/// `k1` is the principal curvature of larger magnitude, `k2` the other — both signed such that a
+/// convex bulge (e.g. an outward-facing sphere) is positive, matching the mesh's own vertex-normal
+/// orientation. `d1`/`d2` are the corresponding unit tangent directions, mutually perpendicular
+/// and perpendicular to the vertex normal (`d2` always `cross(normal, d1)`).
+public struct VertexCurvature: Sendable, Equatable {
+    /// Principal curvature of larger magnitude.
+    public let k1: Double
+    /// Principal curvature of smaller magnitude.
+    public let k2: Double
+    /// Unit tangent direction of `k1`.
+    public let d1: SIMD3<Float>
+    /// Unit tangent direction of `k2` (`= cross(normal, d1)`).
+    public let d2: SIMD3<Float>
+
+    public init(k1: Double, k2: Double, d1: SIMD3<Float>, d2: SIMD3<Float>) {
+        self.k1 = k1
+        self.k2 = k2
+        self.d1 = d1
+        self.d2 = d2
+    }
+
+    /// Mean curvature `(k1 + k2) / 2`.
+    public var mean: Double { (k1 + k2) / 2 }
+    /// Gaussian curvature `k1 * k2`.
+    public var gaussian: Double { k1 * k2 }
+}

--- a/Tests/OCCTSwiftMeshTests/MeshCurvatureTests.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshCurvatureTests.swift
@@ -1,0 +1,138 @@
+import Testing
+import simd
+import OCCTSwift
+@testable import OCCTSwiftMesh
+
+@Suite("Mesh.vertexCurvatures — discrete curvature estimation")
+struct MeshCurvatureTests {
+
+    @Test("Flat grid: zero curvature everywhere, including boundary vertices")
+    func flatPlaneIsZeroCurvature() {
+        let mesh = flatGridMesh()
+        let curvatures = mesh.vertexCurvatures()
+        #expect(curvatures.count == mesh.vertexCount)
+        for c in curvatures {
+            #expect(abs(c.k1) < 1e-4)
+            #expect(abs(c.k2) < 1e-4)
+            #expect(abs(c.mean) < 1e-4)
+            #expect(abs(c.gaussian) < 1e-6)
+        }
+    }
+
+    @Test("Sphere zone: k1 == k2 == 1/radius at interior vertices")
+    func sphereInteriorCurvatureMatchesAnalytic() {
+        let radius: Float = 10
+        let rings = 10
+        let segments = 24
+        let mesh = sphereZoneMesh(radius: radius, latitudeSpanDegrees: 60, segments: segments, rings: rings)
+        let curvatures = mesh.vertexCurvatures()
+        let expected = 1.0 / Double(radius)
+
+        // Interior rings only, excluding a 2-ring buffer from the top/bottom open boundary: the
+        // boundary rings themselves have an incomplete triangle fan (less accurate vertex
+        // normals), and that inaccuracy propagates one ring further inward through the shared
+        // faces used to fit THOSE vertices' neighbors — verified empirically (rings 0/1 and
+        // 8/9 of this 10-ring mesh show a several-% bias; rings 2-7 converge to <0.1%).
+        for ring in 2..<(rings - 2) {
+            for i in 0..<segments {
+                let c = curvatures[ring * segments + i]
+                #expect(abs(c.k1 - expected) < expected * 0.05)
+                #expect(abs(c.k2 - expected) < expected * 0.05)
+                #expect(abs(c.gaussian - expected * expected) < expected * expected * 0.1)
+            }
+        }
+    }
+
+    @Test("Cylinder: k1 == 1/radius, k2 == 0, d2 along the axis, at interior vertices")
+    func cylinderInteriorCurvatureMatchesAnalytic() {
+        let radius: Float = 6
+        let rings = 8
+        let segments = 24
+        let mesh = openCylinderMultiRingMesh(radius: radius, height: 20, segments: segments, rings: rings)
+        let curvatures = mesh.vertexCurvatures()
+        let expected = 1.0 / Double(radius)
+        let axis = SIMD3<Double>(0, 0, 1)
+
+        for ring in 2..<(rings - 2) {
+            for i in 0..<segments {
+                let c = curvatures[ring * segments + i]
+                #expect(abs(c.k1 - expected) < expected * 0.05)
+                #expect(abs(c.k2) < expected * 0.05)
+                // d2 (the k2 == 0 direction) should be parallel to the cylinder's axis; d1
+                // (circumferential) should be perpendicular to it. Sign/labeling of d1 vs d2 is
+                // unambiguous here since |k1| >> |k2|.
+                let d2Alignment = abs(simd_dot(SIMD3<Double>(c.d2), axis))
+                #expect(d2Alignment > 0.98)
+                #expect(abs(simd_dot(SIMD3<Double>(c.d1), axis)) < 0.2)
+            }
+        }
+    }
+
+    @Test("Unwelded input reports zero curvature everywhere — documents the weld precondition")
+    func unweldedInputIsZeroCurvature() {
+        let mesh = unwelded(sphereZoneMesh())
+        let curvatures = mesh.vertexCurvatures()
+        #expect(curvatures.count == mesh.vertexCount)
+        for c in curvatures {
+            #expect(c.k1 == 0)
+            #expect(c.k2 == 0)
+        }
+    }
+
+    @Test("A sliver triangle glued onto an edge doesn't propagate NaN, and leaves every vertex's curvature unchanged")
+    func sliverTriangleIsExcludedNotPropagated() {
+        let base = sphereZoneMesh()
+        let contaminated = sphereZoneMeshWithSliver()
+        let baseCurvatures = base.vertexCurvatures()
+        let contaminatedCurvatures = contaminated.vertexCurvatures()
+
+        #expect(contaminatedCurvatures.count == base.vertexCount + 1)
+        for c in contaminatedCurvatures {
+            #expect(c.k1.isFinite)
+            #expect(c.k2.isFinite)
+            #expect(c.d1.x.isFinite && c.d1.y.isFinite && c.d1.z.isFinite)
+            #expect(c.d2.x.isFinite && c.d2.y.isFinite && c.d2.z.isFinite)
+        }
+        // The sliver's own two shared corners (0, 1) and every untouched vertex are numerically
+        // unaffected — the sliver's contribution is excluded from the curvature FIT entirely
+        // (guard on area/aspect), not merely down-weighted. (Not bit-identical: appending the
+        // sliver triangle also changes which face is "last" to set corners 0/1's arbitrary
+        // initial tangent-frame pick — see the file header — a different but equally valid
+        // orthonormal basis, so the accumulation happens in a different order and picks up
+        // ~1e-6-level floating-point noise, even though the underlying tensor contributions
+        // summed are identical.)
+        for i in 0..<base.vertexCount {
+            #expect(abs(contaminatedCurvatures[i].k1 - baseCurvatures[i].k1) < 1e-5)
+            #expect(abs(contaminatedCurvatures[i].k2 - baseCurvatures[i].k2) < 1e-5)
+        }
+        // The new orphan apex vertex has no OTHER face contributing to it (its only triangle was
+        // excluded), so it degrades cleanly to zero rather than NaN.
+        let apex = contaminatedCurvatures[base.vertexCount]
+        #expect(apex.k1 == 0)
+        #expect(apex.k2 == 0)
+    }
+
+    @Test("Determinism: repeated calls on identical input are bit-identical")
+    func deterministic() {
+        let mesh = sphereZoneMesh()
+        let a = mesh.vertexCurvatures()
+        let b = mesh.vertexCurvatures()
+        #expect(a.count == b.count)
+        for (x, y) in zip(a, b) {
+            #expect(x.k1 == y.k1)
+            #expect(x.k2 == y.k2)
+            #expect(x.d1 == y.d1)
+            #expect(x.d2 == y.d2)
+        }
+    }
+
+    @Test("d1 and d2 are unit length and mutually perpendicular")
+    func principalDirectionsAreOrthonormal() {
+        let mesh = sphereZoneMesh()
+        for c in mesh.vertexCurvatures() {
+            #expect(abs(Double(simd_length(c.d1)) - 1) < 1e-4)
+            #expect(abs(Double(simd_length(c.d2)) - 1) < 1e-4)
+            #expect(abs(Double(simd_dot(c.d1, c.d2))) < 1e-4)
+        }
+    }
+}

--- a/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
@@ -266,3 +266,100 @@ func shallowCylindricalArcMesh(radius: Float = 500, widthUnits: Float = 200, axi
     }
     return Mesh(vertices: positions, indices: indices)!
 }
+
+/// An open cylindrical shell (no end caps) with multiple axial rings — unlike
+/// `openCylinderShellMesh`'s fixed 2 rings (every vertex a boundary vertex), interior rings here
+/// are away from the top/bottom open edges and get a complete triangle fan. Welded by
+/// construction (shared ring vertices); axis is +Z.
+func openCylinderMultiRingMesh(radius: Float = 6, height: Float = 20, segments: Int = 24, rings: Int = 8) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    for k in 0..<rings {
+        let z = Float(k) / Float(rings - 1) * height
+        for i in 0..<segments {
+            let a = Float(i) / Float(segments) * 2 * .pi
+            positions.append(SIMD3(radius * cos(a), radius * sin(a), z))
+        }
+    }
+    var indices: [UInt32] = []
+    for k in 0..<(rings - 1) {
+        let lo = UInt32(k * segments), hi = UInt32((k + 1) * segments)
+        for i in 0..<segments {
+            let a = lo + UInt32(i), b = lo + UInt32((i + 1) % segments)
+            let c = hi + UInt32(i), d = hi + UInt32((i + 1) % segments)
+            indices.append(contentsOf: [a, b, c, b, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// An open "zone" cut from a sphere (a latitude band, no pole caps) — wrapped in longitude, open
+/// top/bottom in latitude. Avoids the pole singularity a full UV-sphere would introduce, so every
+/// interior vertex has the same well-defined analytic curvature (`k1 == k2 == 1/radius`). Welded
+/// by construction (shared ring vertices in longitude).
+func sphereZoneMesh(radius: Float = 10, latitudeSpanDegrees: Float = 60, segments: Int = 24, rings: Int = 10) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    let halfSpan = latitudeSpanDegrees * .pi / 180 / 2
+    for k in 0..<rings {
+        let lat = -halfSpan + Float(k) / Float(rings - 1) * (2 * halfSpan)
+        for i in 0..<segments {
+            let lon = Float(i) / Float(segments) * 2 * .pi
+            let x = radius * cos(lat) * cos(lon)
+            let y = radius * cos(lat) * sin(lon)
+            let z = radius * sin(lat)
+            positions.append(SIMD3(x, y, z))
+        }
+    }
+    var indices: [UInt32] = []
+    for k in 0..<(rings - 1) {
+        let lo = UInt32(k * segments), hi = UInt32((k + 1) * segments)
+        for i in 0..<segments {
+            let a = lo + UInt32(i), b = lo + UInt32((i + 1) % segments)
+            let c = hi + UInt32(i), d = hi + UInt32((i + 1) % segments)
+            indices.append(contentsOf: [a, b, c, b, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// `sphereZoneMesh()` with one extra degenerate SLIVER triangle glued onto the edge between
+/// vertices 0 and 1 (a needle: two shared existing vertices plus one new vertex placed almost
+/// exactly on the line between them) — for exercising `vertexCurvatures()`'s sliver-exclusion
+/// guard without perturbing the rest of the mesh's analytic curvature.
+func sphereZoneMeshWithSliver(radius: Float = 10, latitudeSpanDegrees: Float = 60, segments: Int = 24, rings: Int = 10) -> Mesh {
+    let base = sphereZoneMesh(radius: radius, latitudeSpanDegrees: latitudeSpanDegrees, segments: segments, rings: rings)
+    var positions = base.vertices
+    var indices = base.indices
+    let a = positions[0], b = positions[1]
+    let ab = b - a
+    let helper: SIMD3<Float> = abs(ab.x) < abs(ab.y) ? SIMD3(1, 0, 0) : SIMD3(0, 1, 0)
+    let perpDir = simd_normalize(simd_cross(ab, helper))
+    let sliverApex = (a + b) * 0.5 + perpDir * (simd_length(ab) * 1e-5)
+    let newIndex = UInt32(positions.count)
+    positions.append(sliverApex)
+    indices.append(contentsOf: [0, 1, newIndex])
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A flat rectangular grid in the XY plane (`z == 0`) — the trivial curvature case:
+/// `k1 == k2 == 0` everywhere, including at boundary vertices (flat is flat regardless of an
+/// incomplete triangle fan). Welded by construction (shared grid vertices).
+func flatGridMesh(width: Float = 20, depth: Float = 20, segmentsX: Int = 10, segmentsY: Int = 10) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    for j in 0...segmentsY {
+        let y = Float(j) / Float(segmentsY) * depth
+        for i in 0...segmentsX {
+            let x = Float(i) / Float(segmentsX) * width
+            positions.append(SIMD3(x, y, 0))
+        }
+    }
+    let cols = segmentsX + 1
+    var indices: [UInt32] = []
+    for j in 0..<segmentsY {
+        for i in 0..<segmentsX {
+            let a = UInt32(j * cols + i), b = UInt32(j * cols + i + 1)
+            let c = UInt32((j + 1) * cols + i), d = UInt32((j + 1) * cols + i + 1)
+            indices.append(contentsOf: [a, b, d, a, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to OCCTSwiftMesh.
 
+## v1.4.0 — discrete curvature estimation
+
+Adds `Mesh.vertexCurvatures()` ([#23](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/23)) — per-vertex principal curvatures and directions via the Rusinkiewicz per-face tensor method, pure Swift + simd, ported from the algorithm trimesh2's `TriMesh_curvature.cc` (MIT) and the PMP library's curvature module implement. See [docs/algorithms/curvature.md](algorithms/curvature.md).
+
+```swift
+let welded = mesh.welded()                 // requires welded input, same precondition as
+                                            // triangleAdjacency()/connectedComponents()
+for c in welded.vertexCurvatures() {
+    print(c.k1, c.k2, c.mean, c.gaussian)  // c.d1/c.d2 — unit principal directions
+}
+```
+
+- Chosen over Meyer et al.'s cotan-Laplacian approach specifically for robustness on noisy/
+  irregular real-scan tessellation: no obtuse-triangle clamp anywhere in the pipeline (the cotan
+  approach needs one, and still degrades on slivers).
+- Sliver-robust by construction: a face degenerate or an extreme sliver (near-zero area relative
+  to its longest edge squared) is excluded from the fit entirely — never fed into an
+  ill-conditioned solve that could poison its corners with a garbage tensor. A vertex touched
+  only by excluded faces (or none at all) reports `k1 == k2 == 0`, never `NaN`.
+  `Linalg.solve` returning `nil` and any non-finite intermediate result are both guarded directly
+  too, as defense in depth beyond the area/aspect pre-filter.
+- `k1` is always the eigenvalue of larger magnitude, signed so a convex bulge (e.g. an
+  outward-facing sphere) is positive — matching `vertexNormals()`'s own outward-normal
+  convention. Analytic test fixtures (a sphere zone, an open multi-ring cylinder, a flat grid)
+  confirm this against the closed-form curvature of each shape.
+- Deterministic: no Dictionary/Set iteration in the hot path, and each vertex's arbitrary initial
+  tangent-frame pick doesn't affect the final (eigenvalue-invariant) result.
+
 ## v1.3.0 — #19 review follow-ups (fitMergeSkipped, isWatertight, region-local fit floor)
 
 Follow-ups from the v1.2.0 (#19) review, tracked in [#20](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/20). None affect the correctness of what shipped in v1.2.0; two are behavior fixes, the rest are diagnostics/docs/tests.

--- a/docs/algorithms/curvature.md
+++ b/docs/algorithms/curvature.md
@@ -1,0 +1,80 @@
+# Discrete curvature (`Mesh.vertexCurvatures()`)
+
+Per-vertex principal curvatures and directions via the Rusinkiewicz per-face tensor method
+(Rusinkiewicz, "Estimating Curvatures and Their Derivatives on Triangle Meshes", 3DPVT 2004) —
+the same algorithm trimesh2's `TriMesh_curvature.cc` (MIT) and the PMP library's curvature module
+implement. Pure Swift + simd — no OCCT kernel calls. Requires WELDED input, the same precondition
+as `triangleAdjacency()`/`connectedComponents()` — see [mesh-foundations.md](mesh-foundations.md).
+
+## Why Rusinkiewicz over Meyer's cotan-Laplacian
+
+Meyer et al.'s mixed-area cotan-Laplacian approach is the other well-known discrete-curvature
+method, but it needs an obtuse-triangle clamp: a naive Voronoi-area vertex weight goes negative
+(or the cotan weight blows up) on an obtuse triangle, forcing a fallback rule for that case. Real
+scan meshes have plenty of those — including outright slivers (see `MeshIntegrityReport`'s own
+`minAngleDegrees`/`aspectRatio` sliver signals). Rusinkiewicz's method fits a curvature tensor per
+FACE directly from that face's own edge vectors and vertex-normal differences, then averages face
+tensors onto each vertex — no clamp anywhere in the pipeline, and (this package's choice) a
+simple area-weighted average onto vertices rather than Meyer's mixed Voronoi area, trading a
+little accuracy on the most skewed triangles for one less failure mode to reason about.
+
+## Algorithm sketch
+
+For each face, in an orthonormal `(t, b)` basis tangent to the face (`t` along one edge, `b`
+completing the frame with the face normal):
+
+1. Build a small 3×3 least-squares system from the face's 3 edges: each edge's `(u, v) = (e·t,
+   e·b)` projection, and the corresponding difference in the two OTHER corners' vertex normals
+   (not the face normal — the whole point is to sense how the surface's true normal varies).
+2. Solve for the face's own second-fundamental-form coefficients `(e, f, g)` (the tensor
+   `[[e, f], [f, g]]` in the face's `(t, b)` basis) via `Linalg.solve` (reusing the same Gaussian
+   elimination `PrimitiveFitter` uses — this is genuinely just a 3-unknown linear solve, no need
+   for the dedicated LDLT trimesh2 uses).
+3. Re-express that tensor in each of the face's 3 vertices' own (arbitrary, per-vertex) tangent
+   bases, weight by the face's area, and accumulate.
+4. Per vertex: normalize by the total accumulated weight, then diagonalize the averaged tensor to
+   recover `k1` (larger-magnitude eigenvalue), `k2`, and their tangent directions.
+
+The basis-rotation step (`rotCoordSys`/`projCurv`/`diagonalizeCurv` in `Mesh+Curvature.swift`) is
+ported directly from trimesh2's implementation of the same algorithm — it's the exact minimal
+rotation taking one unit normal to another, not a first-order approximation, so it's valid even
+though a face's own normal and its corners' vertex normals never exactly agree.
+
+Each vertex's initial `(pdir1, pdir2)` tangent basis is arbitrary (the last-encountered incident
+edge, projected orthogonal to the vertex normal, in triangle-index order — deterministic, not
+random) but harmless: since `k1`/`k2` are eigenvalues of the accumulated tensor, they're
+independent of which orthonormal basis the tensor happens to be accumulated in.
+
+## Sign convention
+
+`k1`/`k2` are signed so a convex bulge (e.g. an outward-facing sphere) is **positive** — matching
+`vertexNormals()`'s own outward-normal convention for a consistently-wound mesh. `k1` is always
+the eigenvalue of larger magnitude (matching common practice in the reference implementations);
+for a plane or a sphere, where the two are equal (or in the sphere's case, the eigenspace is
+degenerate), the split between `k1` and `k2` is not geometrically meaningful, just whichever the
+tie-break landed on. `mean = (k1 + k2) / 2`, `gaussian = k1 * k2`.
+
+## Sliver-robust: excluded from the fit, not blown up
+
+A face is excluded from the fit entirely — contributing nothing to its corners' accumulated
+tensors — when it's degenerate (near-zero area) or an extreme sliver (area tiny relative to its
+longest edge squared, i.e. a near-zero minimum angle): feeding such a face's ill-conditioned
+edge/normal-difference system into the solve risks a huge (if still technically finite) garbage
+tensor that would then poison that face's own corners. This is a documented degradation — those
+corners simply don't get this one face's contribution, same as `PrimitiveFitter`'s per-face
+guards — never a silently propagated `NaN`. `Linalg.solve` returning `nil` (a genuinely singular
+system) and any non-finite result from the solve or the final diagonalization are both guarded
+directly, as defense in depth beyond the area/aspect pre-filter.
+
+A vertex touched only by excluded faces (or no faces at all, e.g. an orphan vertex) reports
+`k1 == k2 == 0` rather than `NaN` — the same "degrade to a harmless default" pattern
+`PrimitiveFitter.bestFit` and `welded(tolerance:)` already use elsewhere in this package.
+
+## What's NOT here
+
+Curvature-ordered segmentation seeding (growing low-curvature regions first, leaving high-
+curvature strips as fillet/blend candidates) and a single-body curvature render/heatmap mode are
+both OCCTMCP-side follow-ups layered on top of this primitive (tracked upstream, not in this
+package — see [issue #23](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/23)'s context).
+Curvature DERIVATIVES (the extension of Rusinkiewicz's paper this package doesn't implement) are
+also out of scope — only the curvature tensor itself, not its rate of change.


### PR DESCRIPTION
Closes #23.

## Summary

- `Mesh.vertexCurvatures() -> [VertexCurvature]` — per-vertex principal curvatures/directions via the Rusinkiewicz per-face tensor method (Rusinkiewicz, "Estimating Curvatures and Their Derivatives on Triangle Meshes", 3DPVT 2004), the same algorithm trimesh2's `TriMesh_curvature.cc` (MIT) and PMP's curvature module implement. Pure Swift + simd, no OCCT kernel calls.
- Chosen over Meyer's cotan-Laplacian approach specifically for robustness on noisy/irregular real-scan tessellation: no obtuse-triangle clamp anywhere in the pipeline (the per-face fit solves via `Linalg.solve`, reusing `PrimitiveFitter`'s existing Gaussian-elimination solver; vertex averaging is a simple area weighting, not Meyer's mixed Voronoi area).
- Sliver-robust by construction: a degenerate or extreme-sliver face (near-zero area relative to its longest edge squared) is excluded from the fit entirely rather than risking an ill-conditioned solve poisoning its corners. A vertex touched only by excluded faces reports `k1 == k2 == 0`, never `NaN` — verified by a dedicated test that glues a needle-thin sliver onto an otherwise-analytic mesh and checks every other vertex's curvature is numerically unchanged.
- Requires WELDED input, same precondition as `triangleAdjacency()`/`connectedComponents()` (documented in the file header, mirroring that existing convention rather than welding internally).
- `k1` is signed positive for a convex bulge (outward-facing sphere), matching `vertexNormals()`'s outward-normal convention; always the larger-magnitude eigenvalue.
- New test fixtures: an open sphere "zone" (avoids the UV-sphere pole singularity), a multi-ring open cylinder (so interior vertices get a complete triangle fan, unlike the existing 2-ring `openCylinderShellMesh`), a flat grid, and a sliver-contaminated variant.
- `docs/algorithms/curvature.md` — algorithm writeup, sign convention, sliver-robustness rationale.
- Version bump 1.3.0 → 1.4.0 (new algorithm, per this repo's release convention).

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 68/68 passing, including 7 new curvature tests: flat-plane zero curvature, sphere-zone analytic match (`k1==k2==1/r`, interior rings only — boundary-adjacent rings are excluded with rationale in the test comment), cylinder analytic match (`k1==1/r, k2==0`, `d2` along axis), unwelded-input precondition (documents zero-curvature degradation), sliver exclusion, determinism, and principal-direction orthonormality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)