### PR TITLE
Point-to-plane ICP alignment — Mesh.aligned(to:options:) — v1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ OCCTSwift itself stays focused on its mission as an OCCT wrapper. Mesh algorithm
 
 ## Status
 
-✅ **v1.3.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), and `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
+✅ **v1.4.0** — SemVer-stable. Ships `Mesh.simplified(_:)` (decimation, vendored [meshoptimizer](https://github.com/zeux/meshoptimizer) v1.1), `Mesh.crossSection(plane:)` (planar slicing into closed contours), the mesh connectivity toolkit (`welded`, `faceNormals`, `vertexNormals`, `triangleAdjacency`, `connectedComponents`, `subMesh`, `boundaryLoops`, `integrityReport`), `Mesh.segmented(_:)` (dihedral region-growing + primitive-fit merge), and `Mesh.aligned(to:options:)` (point-to-plane ICP registration). Requires OCCTSwift v1.12.9 or later. See [docs/CHANGELOG.md](docs/CHANGELOG.md).
 
 ## API
 
@@ -103,6 +103,21 @@ for (region, fit) in zip(segmented.regions, segmented.fits) {
 // never silent. segmented.fitMergeSkipped reports when the fit-gated merge pass itself couldn't
 // run (raw region count still over an internal cap after the cheap coplanar pre-merge) — also
 // never silent.
+```
+
+### Alignment — `Mesh.aligned(to:options:)`
+
+Point-to-plane ICP registration: recovers the rigid transform that best aligns this (source) mesh
+onto a reference mesh. PCA/bbox pre-align (tries all 4 sign-valid orientations, keeps the best)
+runs before the iterative refinement; normal-space sampling (on by default) keeps a small
+feature's rare normal direction from being drowned out by a flat majority; trimmed correspondence
+handles partial overlap between the two meshes.
+
+```swift
+if let result = scan.aligned(to: cad) {
+    print(result.transform)       // simd_double4x4 — maps scan's original vertices into cad's frame
+    print(result.residualRMS, result.iterations, result.converged)
+}
 ```
 
 ## Installation

--- a/Sources/OCCTSwiftMesh/AlignOptions.swift
+++ b/Sources/OCCTSwiftMesh/AlignOptions.swift
@@ -1,0 +1,64 @@
+// AlignOptions — input parameters for Mesh.aligned(to:options:).
+
+import OCCTSwift
+
+/// Parameters controlling point-to-plane ICP registration.
+///
+/// ## Example
+///
+/// ```swift
+/// var options = Mesh.AlignOptions()
+/// options.trimFraction = 0.2   // more outlier tolerance for a partial-overlap scan
+/// let result = scan.aligned(to: cad, options: options)
+/// ```
+extension Mesh {
+    public struct AlignOptions: Sendable {
+        /// Maximum number of ICP refinement iterations after the PCA pre-align step.
+        public var maxIterations: Int
+
+        /// Correspondences farther apart than this are rejected outright. `nil` (default)
+        /// auto-derives `0.15 ×` the reference mesh's bounding-box diagonal.
+        public var correspondenceDistanceCap: Double?
+
+        /// After the distance cap, additionally drop the worst `trimFraction` of surviving
+        /// correspondences by point-to-plane residual each iteration (trimmed ICP) — robust to
+        /// partial overlap between the two meshes.
+        public var trimFraction: Double
+
+        /// Run a PCA/bbox pre-alignment pass (centroids + principal axes, trying all 4
+        /// orientation-preserving sign combinations and keeping the one with the lowest quick
+        /// correspondence residual) before the iterative refinement. Point-to-plane ICP only
+        /// converges reliably from a reasonable starting pose.
+        public var preAlign: Bool
+
+        /// Sample source points proportional to normal-direction diversity (Rusinkiewicz &
+        /// Levoy, "Efficient Variants of the ICP Algorithm", 2001) rather than uniformly. On a
+        /// mostly-flat surface with a small feature, uniform sampling lets the flat majority
+        /// dominate the correspondence set and the feature "slide" underneath noise; normal-space
+        /// sampling gives every distinct normal direction — including the feature's rare one —
+        /// comparable representation regardless of how many points share it.
+        public var normalSpaceSampling: Bool
+
+        /// Cap on how many source points are used for correspondence search each iteration (the
+        /// same fixed sample is reused every iteration, for determinism and speed — resampling
+        /// per iteration isn't necessary for convergence and would cost determinism for no
+        /// accuracy benefit at a fixed sample size).
+        public var maxSamples: Int
+
+        public init(
+            maxIterations: Int = 50,
+            correspondenceDistanceCap: Double? = nil,
+            trimFraction: Double = 0.1,
+            preAlign: Bool = true,
+            normalSpaceSampling: Bool = true,
+            maxSamples: Int = 2000
+        ) {
+            self.maxIterations = maxIterations
+            self.correspondenceDistanceCap = correspondenceDistanceCap
+            self.trimFraction = trimFraction
+            self.preAlign = preAlign
+            self.normalSpaceSampling = normalSpaceSampling
+            self.maxSamples = maxSamples
+        }
+    }
+}

--- a/Sources/OCCTSwiftMesh/AlignResult.swift
+++ b/Sources/OCCTSwiftMesh/AlignResult.swift
@@ -1,0 +1,29 @@
+// AlignResult — successful result of Mesh.aligned(to:options:).
+
+import simd
+
+/// The rigid transform that best aligns one mesh onto another (point-to-plane ICP).
+public struct AlignResult: Sendable {
+    /// The rigid transform mapping the SOURCE mesh's original vertex positions onto the
+    /// reference mesh's frame: `transform * SIMD4(sourceVertex, 1)`.
+    public let transform: simd_double4x4
+
+    /// Point-to-plane residual RMS at the returned transform, over the final surviving
+    /// (distance-capped, trimmed) correspondence set.
+    public let residualRMS: Double
+
+    /// Number of ICP refinement iterations actually run (not counting the PCA pre-align step).
+    public let iterations: Int
+
+    /// `true` when the residual RMS stopped improving meaningfully before `maxIterations` was
+    /// reached. `false` means either `maxIterations` was exhausted, or correspondence search
+    /// broke down (too few surviving correspondences to solve the next increment) before that.
+    public let converged: Bool
+
+    public init(transform: simd_double4x4, residualRMS: Double, iterations: Int, converged: Bool) {
+        self.transform = transform
+        self.residualRMS = residualRMS
+        self.iterations = iterations
+        self.converged = converged
+    }
+}

--- a/Sources/OCCTSwiftMesh/KDTree3.swift
+++ b/Sources/OCCTSwiftMesh/KDTree3.swift
@@ -1,0 +1,78 @@
+// KDTree3.swift — a minimal static 3D k-d tree for nearest-neighbor correspondence search.
+// Internal implementation detail behind Mesh.aligned(to:options:); not part of the public API.
+
+import simd
+
+struct KDTree3 {
+    private struct Node {
+        var index: Int
+        var axis: Int
+        var left: Int
+        var right: Int
+    }
+
+    private let points: [SIMD3<Double>]
+    private var nodes: [Node] = []
+    private var root: Int = -1
+
+    /// Builds a balanced tree by recursive median split, alternating axis by depth. DETERMINISM:
+    /// the per-level sort ties-break on point index, so identical input always builds the same
+    /// tree — a plain coordinate sort alone would leave coincident-coordinate ties to whatever
+    /// order the input happened to arrive in (harmless for query correctness, but would leak
+    /// into any tie-broken downstream consumer).
+    init(points: [SIMD3<Double>]) {
+        self.points = points
+        guard !points.isEmpty else { return }
+        var indices = Array(0..<points.count)
+        nodes.reserveCapacity(points.count)
+        root = Self.build(indices: &indices, lo: 0, hi: indices.count, depth: 0, points: points, nodes: &nodes)
+    }
+
+    private static func build(indices: inout [Int], lo: Int, hi: Int, depth: Int,
+                              points: [SIMD3<Double>], nodes: inout [Node]) -> Int {
+        guard lo < hi else { return -1 }
+        let axis = depth % 3
+        let slice = indices[lo..<hi].sorted { a, b in
+            let pa = points[a][axis], pb = points[b][axis]
+            return pa != pb ? pa < pb : a < b
+        }
+        for i in 0..<slice.count { indices[lo + i] = slice[i] }
+        let mid = lo + (hi - lo) / 2
+        let nodeIndex = nodes.count
+        nodes.append(Node(index: indices[mid], axis: axis, left: -1, right: -1))
+        let leftChild = build(indices: &indices, lo: lo, hi: mid, depth: depth + 1, points: points, nodes: &nodes)
+        let rightChild = build(indices: &indices, lo: mid + 1, hi: hi, depth: depth + 1, points: points, nodes: &nodes)
+        nodes[nodeIndex].left = leftChild
+        nodes[nodeIndex].right = rightChild
+        return nodeIndex
+    }
+
+    /// Nearest neighbor to `query`, as `(index into the original points array, distance)`, or
+    /// `nil` if the tree is empty.
+    func nearest(to query: SIMD3<Double>) -> (index: Int, distance: Double)? {
+        guard root >= 0 else { return nil }
+        var bestIndex = -1
+        var bestDistSq = Double.infinity
+        search(node: root, query: query, bestIndex: &bestIndex, bestDistSq: &bestDistSq)
+        guard bestIndex >= 0 else { return nil }
+        return (bestIndex, bestDistSq.squareRoot())
+    }
+
+    private func search(node: Int, query: SIMD3<Double>, bestIndex: inout Int, bestDistSq: inout Double) {
+        guard node >= 0 else { return }
+        let n = nodes[node]
+        let p = points[n.index]
+        let d = query - p
+        let distSq = simd_dot(d, d)
+        if distSq < bestDistSq {
+            bestDistSq = distSq
+            bestIndex = n.index
+        }
+        let diff = query[n.axis] - p[n.axis]
+        let (nearChild, farChild) = diff < 0 ? (n.left, n.right) : (n.right, n.left)
+        search(node: nearChild, query: query, bestIndex: &bestIndex, bestDistSq: &bestDistSq)
+        if diff * diff < bestDistSq {
+            search(node: farChild, query: query, bestIndex: &bestIndex, bestDistSq: &bestDistSq)
+        }
+    }
+}

--- a/Sources/OCCTSwiftMesh/Mesh+Align.swift
+++ b/Sources/OCCTSwiftMesh/Mesh+Align.swift
@@ -1,0 +1,257 @@
+// Mesh+Align.swift — point-to-plane ICP registration with PCA pre-align and normal-space
+// sampling.
+//
+// Ported from the classic ICP literature: Chen & Medioni's point-to-plane objective (converges
+// far faster than point-to-point on engineering surfaces), Rusinkiewicz & Levoy's normal-space
+// sampling ("Efficient Variants of the ICP Algorithm", 2001), and Low's linearized point-to-plane
+// solve ("Linear Least-Squares Optimization for Point-to-Plane ICP", 2004). Pure Swift + simd —
+// no OCCT kernel calls, no vendored library.
+//
+// Welds both meshes internally (for per-point normals and a deduplicated point cloud) — like
+// `segmented(_:)`, not like `triangleAdjacency()` — since alignment is a composite, mesh-level
+// operation, not a low-level connectivity primitive the caller is expected to pre-weld for.
+
+import Foundation
+import simd
+import OCCTSwift
+
+extension Mesh {
+
+    /// Rigid-transform registration of this (SOURCE) mesh onto `reference`, via point-to-plane
+    /// ICP. Returns `nil` if either mesh has too few points to register (fewer than 3 after
+    /// welding).
+    ///
+    /// `result.transform` maps THIS mesh's original vertex positions into `reference`'s frame.
+    public func aligned(to reference: Mesh, options: AlignOptions = .init()) -> AlignResult? {
+        let sourceWelded = welded()
+        let refWelded = reference.welded()
+        let sourcePoints = sourceWelded.vertices.map { SIMD3<Double>($0) }
+        let refPoints = refWelded.vertices.map { SIMD3<Double>($0) }
+        guard sourcePoints.count >= 3, refPoints.count >= 3 else { return nil }
+
+        let sourceNormals = sourceWelded.vertexNormals().map { SIMD3<Double>($0) }
+        let refNormals = refWelded.vertexNormals().map { SIMD3<Double>($0) }
+
+        var lo = refPoints[0], hi = refPoints[0]
+        for p in refPoints { lo = simd_min(lo, p); hi = simd_max(hi, p) }
+        let bboxDiag = simd_length(hi - lo)
+        let distanceCap = options.correspondenceDistanceCap ?? max(1e-9, 0.15 * bboxDiag)
+
+        let tree = KDTree3(points: refPoints)
+
+        let sampleCount = max(0, min(options.maxSamples, sourcePoints.count))
+        let sampleIndices = options.normalSpaceSampling
+            ? Mesh.normalSpaceSample(normals: sourceNormals, count: sampleCount)
+            : Mesh.uniformSample(total: sourcePoints.count, take: sampleCount)
+        let samplePoints = sampleIndices.map { sourcePoints[$0] }
+
+        var pose = options.preAlign
+            ? Mesh.pcaPrealign(source: sourcePoints, reference: refPoints, tree: tree)
+            : matrix_identity_double4x4
+
+        func correspondences(at pose: simd_double4x4) -> [(src: SIMD3<Double>, ref: SIMD3<Double>, normal: SIMD3<Double>)] {
+            samplePoints.compactMap { p in
+                let tp = Mesh.apply(pose, p)
+                guard let (idx, dist) = tree.nearest(to: tp), dist <= distanceCap else { return nil }
+                return (tp, refPoints[idx], refNormals[idx])
+            }
+        }
+
+        let convergenceEps = max(1e-12, 1e-7 * bboxDiag)
+        var lastRMS = Double.infinity
+        var iterations = 0
+        var converged = false
+
+        let maxIterations = max(0, options.maxIterations)
+        for iter in 0..<maxIterations {
+            let corr = correspondences(at: pose)
+            guard corr.count >= 6 else { break }
+
+            let residuals = corr.map { abs(simd_dot($0.normal, $0.src - $0.ref)) }
+            let rms = (residuals.reduce(0) { $0 + $1 * $1 } / Double(residuals.count)).squareRoot()
+
+            if iter > 0, abs(lastRMS - rms) < convergenceEps {
+                converged = true
+                lastRMS = rms
+                break
+            }
+            lastRMS = rms
+            iterations = iter + 1
+
+            // Trimmed ICP: keep the best (1 - trimFraction) of correspondences by residual
+            // magnitude. DETERMINISM: tie-break by original correspondence order.
+            let keepCount = max(6, Int((Double(corr.count) * (1 - max(0, min(0.9, options.trimFraction)))).rounded()))
+            let order = residuals.indices.sorted { residuals[$0] != residuals[$1] ? residuals[$0] < residuals[$1] : $0 < $1 }
+            let kept = order.prefix(min(keepCount, order.count)).map { corr[$0] }
+            guard kept.count >= 6 else { break }
+
+            // Low (2004) linearized point-to-plane solve for a small incremental rigid transform
+            // (r = small-angle rotation vector, t = translation): for each correspondence,
+            // n·((p + r×p + t) - q) = 0  =>  (p×n)·r + n·t = n·(q - p).
+            var ata = [[Double]](repeating: [Double](repeating: 0, count: 6), count: 6)
+            var atb = [Double](repeating: 0, count: 6)
+            for c in kept {
+                let pxn = simd_cross(c.src, c.normal)
+                let row = [pxn.x, pxn.y, pxn.z, c.normal.x, c.normal.y, c.normal.z]
+                let rhs = simd_dot(c.normal, c.ref - c.src)
+                for i in 0..<6 {
+                    atb[i] += row[i] * rhs
+                    for j in 0..<6 { ata[i][j] += row[i] * row[j] }
+                }
+            }
+            guard let sol = Linalg.solve(ata, atb) else { break }
+            guard sol.allSatisfy({ $0.isFinite }) else { break }
+
+            let r = SIMD3<Double>(sol[0], sol[1], sol[2])
+            let t = SIMD3<Double>(sol[3], sol[4], sol[5])
+            let angle = simd_length(r)
+            let rotation = angle > 1e-14 ? Mesh.rodrigues(axis: r / angle, angle: angle) : matrix_identity_double3x3
+            let incremental = Mesh.rigidTransform(rotation: rotation, translation: t)
+            pose = simd_mul(incremental, pose)
+        }
+
+        // Report the residual at the FINAL pose (post-last-increment), not the pose one step
+        // prior — a fresh correspondence pass, cheap relative to the iterations already run.
+        let finalCorr = correspondences(at: pose)
+        let finalRMS = finalCorr.isEmpty
+            ? lastRMS
+            : (finalCorr.map { let d = simd_dot($0.normal, $0.src - $0.ref); return d * d }.reduce(0, +) / Double(finalCorr.count)).squareRoot()
+
+        return AlignResult(transform: pose, residualRMS: finalRMS, iterations: iterations, converged: converged)
+    }
+
+    // MARK: - PCA pre-align
+
+    /// Centroid + principal-axis pre-alignment, trying all 4 orientation-preserving sign
+    /// combinations of the two dominant axes (PCA eigenvectors have no inherent sign — the
+    /// third axis is always re-derived via cross product to keep an orthonormal, right-handed
+    /// frame) and keeping whichever gives the lowest quick correspondence residual. Deterministic:
+    /// candidates are tried in a fixed order and ties broken by that same order.
+    static func pcaPrealign(source: [SIMD3<Double>], reference: [SIMD3<Double>], tree: KDTree3) -> simd_double4x4 {
+        let (srcCov, srcCentroid) = Linalg.covariance(source)
+        let (refCov, refCentroid) = Linalg.covariance(reference)
+        let (_, srcVecs) = Linalg.eigenSymmetric3(srcCov)
+        let (_, refVecs) = Linalg.eigenSymmetric3(refCov)
+
+        // eigenSymmetric3 returns ascending eigenvalues; index 2 is the dominant axis.
+        let srcA0 = SIMD3<Double>(srcVecs[2][0], srcVecs[2][1], srcVecs[2][2])
+        let srcA1 = SIMD3<Double>(srcVecs[1][0], srcVecs[1][1], srcVecs[1][2])
+        let refA0 = SIMD3<Double>(refVecs[2][0], refVecs[2][1], refVecs[2][2])
+        let refA1 = SIMD3<Double>(refVecs[1][0], refVecs[1][1], refVecs[1][2])
+        let refBasis = simd_double3x3(columns: (refA0, refA1, simd_cross(refA0, refA1)))
+
+        let signCombos: [(Double, Double)] = [(1, 1), (1, -1), (-1, 1), (-1, -1)]
+        let sampleStride = max(1, source.count / 200)
+
+        var best: (transform: simd_double4x4, score: Double)?
+        for (s0, s1) in signCombos {
+            let a0 = s0 * srcA0, a1 = s1 * srcA1
+            let srcBasis = simd_double3x3(columns: (a0, a1, simd_cross(a0, a1)))
+            let rotation = simd_mul(refBasis, srcBasis.transpose)
+            let translation = refCentroid - simd_mul(rotation, srcCentroid)
+            let candidate = Mesh.rigidTransform(rotation: rotation, translation: translation)
+
+            var sumDist = 0.0, n = 0
+            var i = 0
+            while i < source.count {
+                let tp = Mesh.apply(candidate, source[i])
+                if let (_, dist) = tree.nearest(to: tp) { sumDist += dist; n += 1 }
+                i += sampleStride
+            }
+            let score = n > 0 ? sumDist / Double(n) : .infinity
+            if best == nil || score < best!.score { best = (candidate, score) }
+        }
+        return best?.transform ?? matrix_identity_double4x4
+    }
+
+    // MARK: - Sampling
+
+    /// Sample `count` indices proportional to normal-direction diversity: bucket by normal
+    /// direction (a coarse lat/long grid), then round-robin across NON-EMPTY buckets in a fixed
+    /// order so every direction gets comparable representation regardless of population size —
+    /// the flat majority of a mostly-planar surface doesn't crowd out a small feature's rare
+    /// normal direction. Deterministic (fixed bucket order, in-bucket order by point index).
+    static func normalSpaceSample(normals: [SIMD3<Double>], count: Int) -> [Int] {
+        guard count > 0, !normals.isEmpty else { return [] }
+        guard count < normals.count else { return Array(0..<normals.count) }
+
+        let lonBuckets = 12, latBuckets = 6
+        func bucket(_ n: SIMD3<Double>) -> Int {
+            let len = simd_length(n)
+            let u = len > 1e-12 ? n / len : SIMD3<Double>(0, 0, 1)
+            let lon = atan2(u.y, u.x)
+            let lat = asin(max(-1, min(1, u.z)))
+            let lonIdx = min(lonBuckets - 1, Int((lon + .pi) / (2 * .pi) * Double(lonBuckets)))
+            let latIdx = min(latBuckets - 1, Int((lat + .pi / 2) / .pi * Double(latBuckets)))
+            return latIdx * lonBuckets + lonIdx
+        }
+
+        var buckets: [Int: [Int]] = [:]
+        for i in normals.indices { buckets[bucket(normals[i]), default: []].append(i) }
+        let bucketKeys = buckets.keys.sorted()
+
+        var cursors = [Int: Int](minimumCapacity: bucketKeys.count)
+        for k in bucketKeys { cursors[k] = 0 }
+
+        var picked: [Int] = []
+        picked.reserveCapacity(count)
+        var anyProgress = true
+        while picked.count < count, anyProgress {
+            anyProgress = false
+            for k in bucketKeys {
+                guard picked.count < count else { break }
+                let list = buckets[k]!
+                let cur = cursors[k]!
+                guard cur < list.count else { continue }
+                picked.append(list[cur])
+                cursors[k] = cur + 1
+                anyProgress = true
+            }
+        }
+        return picked
+    }
+
+    /// Deterministic even-stride subsample of `0..<total`, `take` indices (or all of them, if
+    /// `take >= total`).
+    static func uniformSample(total: Int, take: Int) -> [Int] {
+        guard take > 0, total > 0 else { return [] }
+        guard take < total else { return Array(0..<total) }
+        let stride = Double(total) / Double(take)
+        var result: [Int] = []
+        result.reserveCapacity(take)
+        var seen = Set<Int>()
+        var i = 0
+        while result.count < take, i < total {
+            let idx = min(total - 1, Int(Double(i) * stride))
+            if seen.insert(idx).inserted { result.append(idx) }
+            i += 1
+        }
+        return result
+    }
+
+    // MARK: - Rigid-transform helpers
+
+    static func apply(_ m: simd_double4x4, _ p: SIMD3<Double>) -> SIMD3<Double> {
+        let v = simd_mul(m, SIMD4<Double>(p.x, p.y, p.z, 1))
+        return SIMD3<Double>(v.x, v.y, v.z)
+    }
+
+    static func rigidTransform(rotation: simd_double3x3, translation: SIMD3<Double>) -> simd_double4x4 {
+        let c0 = SIMD4<Double>(rotation.columns.0, 0)
+        let c1 = SIMD4<Double>(rotation.columns.1, 0)
+        let c2 = SIMD4<Double>(rotation.columns.2, 0)
+        let c3 = SIMD4<Double>(translation, 1)
+        return simd_double4x4(columns: (c0, c1, c2, c3))
+    }
+
+    /// Rotation matrix for a right-handed rotation of `angle` radians about unit `axis`
+    /// (Rodrigues' rotation formula).
+    static func rodrigues(axis: SIMD3<Double>, angle: Double) -> simd_double3x3 {
+        let c = cos(angle), s = sin(angle), t = 1 - c
+        let x = axis.x, y = axis.y, z = axis.z
+        let col0 = SIMD3<Double>(c + t * x * x, s * z + t * x * y, -s * y + t * x * z)
+        let col1 = SIMD3<Double>(-s * z + t * y * x, c + t * y * y, s * x + t * y * z)
+        let col2 = SIMD3<Double>(s * y + t * z * x, -s * x + t * z * y, c + t * z * z)
+        return simd_double3x3(columns: (col0, col1, col2))
+    }
+}

--- a/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
+++ b/Sources/OCCTSwiftMesh/OCCTSwiftMesh.swift
@@ -8,6 +8,8 @@
 //   .integrityReport() — the mesh connectivity toolkit and quality/validity snapshot.
 // Mesh.segmented(_:) — dihedral region-growing + primitive-fit merge, splitting a mesh
 //   into plane/cylinder/sphere/cone surface regions.
+// Mesh.aligned(to:options:) — point-to-plane ICP registration (PCA pre-align +
+//   normal-space sampling + trimmed correspondence).
 // See docs/CHANGELOG.md and docs/algorithms/.
 
 /// Namespace marker for the OCCTSwiftMesh module. The public surface lives
@@ -16,5 +18,5 @@
 /// to attach the module's documentation to.
 public enum OCCTSwiftMesh {
     /// Package version. Bump on each tagged release.
-    public static let version = "1.3.0"
+    public static let version = "1.4.0"
 }

--- a/Tests/OCCTSwiftMeshTests/MeshAlignTests.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshAlignTests.swift
@@ -1,0 +1,145 @@
+import Testing
+import simd
+import OCCTSwift
+@testable import OCCTSwiftMesh
+
+@Suite("Mesh.aligned(to:options:) — point-to-plane ICP registration")
+struct MeshAlignTests {
+
+    @Test("Recovers a known applied rigid transform")
+    func recoversKnownTransform() {
+        let reference = bumpyPatchMesh(xRange: 0...20, yRange: 0...20, segmentsPerUnit: 2)
+        let rotation = Mesh.rodrigues(axis: simd_normalize(SIMD3<Double>(0.3, 1, 0.2)), angle: 0.35)
+        let translation = SIMD3<Double>(6, -4, 3)
+        let applied = Mesh.rigidTransform(rotation: rotation, translation: translation)
+        let source = transformedMesh(reference, by: applied)
+
+        guard let result = source.aligned(to: reference) else {
+            Issue.record("alignment returned nil")
+            return
+        }
+        #expect(result.residualRMS < 0.05)
+
+        // result.transform should undo `applied`: composing them maps every reference point back
+        // to itself.
+        let composed = simd_mul(result.transform, applied)
+        for v in reference.vertices {
+            let p = SIMD3<Double>(v)
+            let mapped = Mesh.apply(composed, p)
+            #expect(simd_length(mapped - p) < 0.1)
+        }
+    }
+
+    @Test("Partial overlap: converges to the correct overlap region's alignment, not a wrong plausible one")
+    func partialOverlapConverges() {
+        // Two same-size, same-aspect-ratio (20×20) patches of the SAME underlying bumpy surface
+        // (shared world coordinates), offset in X — a genuine partial-overlap case (60% overlap,
+        // not two identical meshes), with matching overall footprints so PCA pre-align's
+        // principal-axis correspondence isn't itself ambiguous (a separate concern from what
+        // this test targets: the trim/cap mechanism).
+        // A low frequency (period ~105, far larger than the ~28-unit combined patch extent) so
+        // the surface has no repeating pattern within the test's range — a periodic surface here
+        // would let ICP alias onto a wrong-but-locally-plausible phase shift, which is a fixture
+        // problem (a naturally non-repeating real scan wouldn't have this ambiguity), not what
+        // this test targets (the trim/cap mechanism itself).
+        let patchA = bumpyPatchMesh(xRange: 0...20, yRange: 0...20, segmentsPerUnit: 2, frequency: 0.06)
+        let patchBReference = bumpyPatchMesh(xRange: 8...28, yRange: 0...20, segmentsPerUnit: 2, frequency: 0.06)
+
+        let rotation = Mesh.rodrigues(axis: SIMD3<Double>(0, 0, 1), angle: 0.05)
+        let translation = SIMD3<Double>(1.5, -0.8, 0.4)
+        let applied = Mesh.rigidTransform(rotation: rotation, translation: translation)
+        let patchBSource = transformedMesh(patchBReference, by: applied)
+
+        var options = Mesh.AlignOptions()
+        options.trimFraction = 0.45   // ~40% of patchB (x in [20, 28]) falls outside patchA
+        guard let result = patchBSource.aligned(to: patchA, options: options) else {
+            Issue.record("alignment returned nil")
+            return
+        }
+        let composed = simd_mul(result.transform, applied)
+        // Check only points that actually lie in the overlap region (patchBReference's own
+        // vertices there coincide with patchA's surface).
+        var checked = 0
+        for v in patchBReference.vertices where v.x >= 8.5 && v.x <= 19.5 {
+            let p = SIMD3<Double>(v)
+            let mapped = Mesh.apply(composed, p)
+            #expect(simd_length(mapped - p) < 0.3)
+            checked += 1
+        }
+        #expect(checked > 10)
+    }
+
+    @Test("Normal-space sampling guarantees a minority feature-normal direction gets representation; uniform sampling can miss it entirely")
+    func normalSpaceSamplingRepresentsMinorityFeature() {
+        // Off-center, off-diagonal bump placement: a centered bump sits exactly on the raster
+        // path uniform even-stride sampling walks on a regular row-major grid (row·cols + col
+        // aliases with the stride near the diagonal), which would let uniform sampling hit the
+        // feature by grid-aliasing coincidence rather than genuine representation — not what this
+        // test is checking.
+        let mesh = flatWithBumpMesh(bumpCenter: SIMD2(7, 29), bumpSigma: 1.5)
+        let normals = mesh.vertexNormals().map { SIMD3<Double>($0) }
+
+        // "Feature" vertices: those whose normal deviates meaningfully (> 10°) from the flat
+        // majority's (0, 0, 1) — a small minority by construction (a small, localized bump).
+        let featureIndices = Set(normals.indices.filter { i in
+            let z = max(-1, min(1, normals[i].z))
+            return acos(z) * 180 / .pi > 10
+        })
+        #expect(!featureIndices.isEmpty)
+        #expect(Double(featureIndices.count) / Double(normals.count) < 0.05)
+
+        let budget = 40
+        let normalSpacePicks = Set(Mesh.normalSpaceSample(normals: normals, count: budget))
+        let uniformPicks = Set(Mesh.uniformSample(total: normals.count, take: budget))
+
+        #expect(!normalSpacePicks.isDisjoint(with: featureIndices))
+        #expect(uniformPicks.isDisjoint(with: featureIndices))
+    }
+
+    @Test("End to end: normal-space sampling on the flat+feature mesh recovers an in-plane translation a flat plane alone couldn't disambiguate")
+    func normalSpaceSamplingEndToEndRecoversInPlaneShift() {
+        let reference = flatWithBumpMesh()
+        let translation = SIMD3<Double>(3, 2, 0)
+        let applied = Mesh.rigidTransform(rotation: matrix_identity_double3x3, translation: translation)
+        let source = transformedMesh(reference, by: applied)
+
+        var options = Mesh.AlignOptions()
+        options.maxSamples = 40
+        options.normalSpaceSampling = true
+        guard let result = source.aligned(to: reference, options: options) else {
+            Issue.record("alignment returned nil")
+            return
+        }
+        let composed = simd_mul(result.transform, applied)
+        let origin = SIMD3<Double>(0, 0, 0)
+        #expect(simd_length(Mesh.apply(composed, origin) - origin) < 0.5)
+    }
+
+    @Test("Determinism: repeated calls on identical input are bit-identical")
+    func deterministic() {
+        let reference = bumpyPatchMesh(xRange: 0...20, yRange: 0...20, segmentsPerUnit: 2)
+        let applied = Mesh.rigidTransform(
+            rotation: Mesh.rodrigues(axis: simd_normalize(SIMD3<Double>(0.1, 0.9, 0.3)), angle: 0.2),
+            translation: SIMD3<Double>(2, 1, 1))
+        let source = transformedMesh(reference, by: applied)
+
+        let a = source.aligned(to: reference)
+        let b = source.aligned(to: reference)
+        guard let a, let b else {
+            Issue.record("alignment returned nil")
+            return
+        }
+        #expect(a.transform == b.transform)
+        #expect(a.residualRMS == b.residualRMS)
+        #expect(a.iterations == b.iterations)
+        #expect(a.converged == b.converged)
+    }
+
+    @Test("Too few points returns nil rather than crashing")
+    func tooFewPointsReturnsNil() {
+        let tiny = Mesh(vertices: [SIMD3(0, 0, 0), SIMD3(1, 0, 0)], indices: [0, 1, 0])!
+        let reference = bumpyPatchMesh(xRange: 0...20, yRange: 0...20, segmentsPerUnit: 2)
+        #expect(tiny.aligned(to: reference) == nil)
+        #expect(reference.aligned(to: tiny) == nil)
+    }
+}

--- a/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
+++ b/Tests/OCCTSwiftMeshTests/MeshFixtures.swift
@@ -1,5 +1,6 @@
 import simd
 import OCCTSwift
+@testable import OCCTSwiftMesh
 
 // Shared synthetic-mesh builders for the mesh-foundations and segmentation test suites.
 // All pure geometry — no OCCT tessellation needed, mirroring CrossSectionTests' approach.
@@ -265,4 +266,71 @@ func shallowCylindricalArcMesh(radius: Float = 500, widthUnits: Float = 200, axi
         }
     }
     return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A genuinely 3D-shaped ("bumpy terrain") rectangular patch: `z = amplitude · sin(x·freq) ·
+/// cos(y·freq·0.7)` over `xRange`/`yRange`, sampled on a regular grid — real curvature/asymmetry
+/// everywhere (no flat or rotationally-symmetric regions to confuse ICP correspondence), and
+/// GLOBALLY CONSISTENT world coordinates: two patches built from overlapping ranges genuinely
+/// overlap in world space (same `z = f(x, y)` everywhere), for partial-overlap alignment tests.
+/// Welded by construction (shared grid vertices).
+func bumpyPatchMesh(xRange: ClosedRange<Float>, yRange: ClosedRange<Float> = 0...20,
+                    segmentsPerUnit: Float = 1, amplitude: Float = 3, frequency: Float = 0.3) -> Mesh {
+    let segmentsX = max(2, Int((xRange.upperBound - xRange.lowerBound) * segmentsPerUnit))
+    let segmentsY = max(2, Int((yRange.upperBound - yRange.lowerBound) * segmentsPerUnit))
+    var positions: [SIMD3<Float>] = []
+    for j in 0...segmentsY {
+        let y = yRange.lowerBound + Float(j) / Float(segmentsY) * (yRange.upperBound - yRange.lowerBound)
+        for i in 0...segmentsX {
+            let x = xRange.lowerBound + Float(i) / Float(segmentsX) * (xRange.upperBound - xRange.lowerBound)
+            let z = amplitude * sin(x * frequency) * cos(y * frequency * 0.7)
+            positions.append(SIMD3(x, y, z))
+        }
+    }
+    let cols = segmentsX + 1
+    var indices: [UInt32] = []
+    for j in 0..<segmentsY {
+        for i in 0..<segmentsX {
+            let a = UInt32(j * cols + i), b = UInt32(j * cols + i + 1)
+            let c = UInt32((j + 1) * cols + i), d = UInt32((j + 1) * cols + i + 1)
+            indices.append(contentsOf: [a, b, d, a, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// A mostly-flat rectangular grid (`z ≈ 0` almost everywhere) with a single localized Gaussian
+/// bump — the normal-space-sampling motivating case: the bump's tilted-normal vertices are a
+/// small minority of the mesh, everywhere else the normal is uniformly `(0, 0, 1)`. One regular
+/// grid (no stitching), welded by construction (shared grid vertices).
+func flatWithBumpMesh(size: Float = 40, segments: Int = 40, bumpCenter: SIMD2<Float> = SIMD2(20, 20),
+                      bumpSigma: Float = 1.5, bumpHeight: Float = 4) -> Mesh {
+    var positions: [SIMD3<Float>] = []
+    for j in 0...segments {
+        let y = Float(j) / Float(segments) * size
+        for i in 0...segments {
+            let x = Float(i) / Float(segments) * size
+            let dx = x - bumpCenter.x, dy = y - bumpCenter.y
+            let z = bumpHeight * exp(-(dx * dx + dy * dy) / (2 * bumpSigma * bumpSigma))
+            positions.append(SIMD3(x, y, z))
+        }
+    }
+    let cols = segments + 1
+    var indices: [UInt32] = []
+    for j in 0..<segments {
+        for i in 0..<segments {
+            let a = UInt32(j * cols + i), b = UInt32(j * cols + i + 1)
+            let c = UInt32((j + 1) * cols + i), d = UInt32((j + 1) * cols + i + 1)
+            indices.append(contentsOf: [a, b, d, a, d, c])
+        }
+    }
+    return Mesh(vertices: positions, indices: indices)!
+}
+
+/// Applies a rigid transform to every vertex of `mesh`, keeping its indices unchanged.
+func transformedMesh(_ mesh: Mesh, by transform: simd_double4x4) -> Mesh {
+    let newPositions = mesh.vertices.map { v -> SIMD3<Float> in
+        SIMD3<Float>(Mesh.apply(transform, SIMD3<Double>(v)))
+    }
+    return Mesh(vertices: newPositions, indices: mesh.indices)!
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to OCCTSwiftMesh.
 
+## v1.4.0 — point-to-plane ICP alignment
+
+Adds `Mesh.aligned(to:options:)` ([#22](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/22)) — point-to-plane ICP registration (PCA pre-align, normal-space sampling, trimmed correspondence), pure Swift + simd, no vendored library. See [docs/algorithms/alignment.md](algorithms/alignment.md).
+
+```swift
+let result = scan.aligned(to: cad)   // Mesh.AlignOptions() defaults
+if let result {
+    print(result.transform, result.residualRMS, result.iterations, result.converged)
+}
+```
+
+- PCA/bbox pre-align tries all 4 orientation-preserving sign combinations of the two dominant
+  principal axes (PCA eigenvectors have no inherent sign) and keeps whichever gives the lowest
+  quick correspondence residual — avoiding a silently-wrong 180°-flipped starting pose.
+- Normal-space sampling (Rusinkiewicz & Levoy, 2001) is on by default: source points are bucketed
+  by their own normal direction and picked round-robin across buckets, so a small feature's rare
+  normal direction gets comparable representation to the flat majority regardless of population
+  size — the flat majority can no longer make the feature "slide" underneath noise.
+- Trimmed ICP (distance cap + additional worst-`trimFraction` residual trim) handles partial
+  overlap between the two meshes without converging to a wrong-but-locally-plausible alignment of
+  just the non-overlapping parts.
+- `AlignResult.residualRMS` is measured at the RETURNED pose (a final correspondence pass after
+  the loop), not the pose one iteration prior.
+- Deterministic: the internal k-d tree's median split, normal-space sampling's bucket order, and
+  trimmed-correspondence ties all have explicit tie-breaks; PCA pre-align's 4 candidates are
+  tried in a fixed order.
+- Returns `nil` for degenerate input (either mesh has fewer than 3 points after welding) rather
+  than a meaningless transform.
+
 ## v1.3.0 — #19 review follow-ups (fitMergeSkipped, isWatertight, region-local fit floor)
 
 Follow-ups from the v1.2.0 (#19) review, tracked in [#20](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/20). None affect the correctness of what shipped in v1.2.0; two are behavior fixes, the rest are diagnostics/docs/tests.

--- a/docs/algorithms/alignment.md
+++ b/docs/algorithms/alignment.md
@@ -1,0 +1,74 @@
+# Alignment (`Mesh.aligned(to:options:)`)
+
+Point-to-plane ICP registration recovering the rigid transform (rotation + translation) that best
+aligns this mesh (the SOURCE) onto a reference mesh. Pure Swift + simd — no OCCT kernel calls, no
+vendored library. Ported from the classic ICP literature: Chen & Medioni's point-to-plane
+objective, Rusinkiewicz & Levoy's normal-space sampling ("Efficient Variants of the ICP
+Algorithm", 2001), and Low's linearized point-to-plane solve ("Linear Least-Squares Optimization
+for Point-to-Plane ICP", 2004). Welds both meshes internally (for per-point normals and a
+deduplicated point cloud) — a composite, mesh-level operation, not a low-level connectivity
+primitive the caller pre-welds for, unlike `triangleAdjacency()`/`vertexCurvatures()`.
+
+## Why point-to-plane, and why it needs a good starting pose
+
+Point-to-plane ICP minimizes each correspondence's distance to the reference surface's TANGENT
+PLANE rather than to the reference point itself — it converges far faster on engineering surfaces
+than point-to-point ICP (Chen & Medioni), but only from a reasonable starting pose: like any
+gradient-descent-style local optimization, it can converge to the wrong local minimum from a bad
+start. `AlignOptions.preAlign` (on by default) fixes this with a PCA/bbox pre-alignment pass
+before the iterative refinement — see below.
+
+## Algorithm sketch
+
+1. **Weld + normals.** Both meshes are welded internally; reference vertex normals become the
+   plane normals correspondences are measured against.
+2. **PCA pre-align** (`AlignOptions.preAlign`). Align centroids and principal axes — but PCA
+   eigenvectors have no inherent sign, so a naive single choice can pick a 180°-flipped starting
+   pose. This package tries all 4 orientation-preserving sign combinations of the two dominant
+   axes (the third axis is always re-derived via cross product to keep an orthonormal,
+   right-handed frame — never an improper/reflected one) and keeps whichever gives the lowest
+   quick correspondence residual over a coarse subsample. Deterministic: candidates are tried in
+   a fixed order, ties broken by that order.
+3. **Normal-space sampling** (`AlignOptions.normalSpaceSampling`, on by default — mandatory in
+   practice per the tracking issue). Source points are bucketed by their own normal direction (a
+   coarse lat/long grid) and picked round-robin across non-empty buckets in a fixed order, rather
+   than uniformly. On a mostly-flat surface with a small feature, uniform sampling lets the flat
+   majority dominate the correspondence set and the feature "slide" underneath noise — normal-
+   space sampling gives every distinct normal direction, including the feature's rare one,
+   comparable representation regardless of how many points share it. The sample is a FIXED
+   subset, computed once and reused every iteration (not resampled per iteration) — deterministic,
+   and resampling isn't necessary for convergence at a fixed sample size.
+4. **Per iteration:** find each sampled point's nearest reference point (a k-d tree over the
+   welded reference positions — `KDTree3.swift`, an internal implementation detail), reject
+   correspondences farther apart than `correspondenceDistanceCap` (auto: `0.15 ×` the reference
+   mesh's bounding-box diagonal), then additionally trim the worst `trimFraction` of SURVIVING
+   correspondences by point-to-plane residual (trimmed ICP — robust to partial overlap). Solve
+   Low's linearized 6-DOF system for the incremental rigid transform via `Linalg.solve` (the same
+   generic Gaussian-elimination solver `PrimitiveFitter` and `vertexCurvatures()` use, just at
+   6×6 instead of 3×3 or 4×4), and compose it onto the running pose. Stop when the residual RMS
+   stops improving meaningfully, when `maxIterations` is reached, or when too few correspondences
+   survive to solve the next increment (fewer than 6).
+5. **Report.** `AlignResult.residualRMS` is measured with one final correspondence pass at the
+   RETURNED pose (not the pose one iteration prior), for an accurate reported metric.
+
+## Sign/rotation conventions
+
+`AlignResult.transform` maps the SOURCE mesh's ORIGINAL vertex positions into the reference
+mesh's frame. The incremental-rotation solve uses Rodrigues' rotation formula directly (exact for
+any angle, not a small-angle linearization of the rotation ITSELF — only the linear SYSTEM being
+solved for the incremental rotation vector is a small-angle approximation, standard for ICP).
+
+## Determinism
+
+No Dictionary/Set iteration affects results order: the k-d tree's per-level median split sorts
+with an index tie-break, normal-space sampling's bucket order is a sorted key list, and the
+trimmed-correspondence sort ties-break on original order. PCA pre-align's 4 candidates are tried
+in the same fixed order every run.
+
+## What's NOT here
+
+The GOM-style alignment-MODE enum (pre-align / best-fit / local-best-fit / 3-2-1 / RPS-datum) and
+`OCCTMCP`'s `align_bodies` tool are layered on top of this primitive on the OCCTMCP side (tracked
+upstream, not in this package — see
+[issue #22](https://github.com/SecondMouseAU/OCCTSwiftMesh/issues/22)'s context). This is just the
+registration primitive itself.


### PR DESCRIPTION
Closes #22.

## Summary

- `Mesh.aligned(to:options:) -> AlignResult?` — point-to-plane ICP registration recovering the rigid transform that best aligns this (source) mesh onto a reference mesh. Pure Swift + simd, no vendored library.
- **PCA/bbox pre-align** (`AlignOptions.preAlign`, on by default): aligns centroids + principal axes, trying all 4 orientation-preserving sign combinations of the two dominant axes (PCA eigenvectors have no inherent sign — the third axis is always re-derived via cross product to keep an orthonormal, right-handed frame) and keeping whichever gives the lowest quick correspondence residual. Avoids silently picking a 180°-flipped starting pose.
- **Normal-space sampling** (`AlignOptions.normalSpaceSampling`, on by default per the issue's "mandatory in practice" requirement): source points bucketed by their own normal direction, picked round-robin across non-empty buckets — a small feature's rare normal direction gets comparable representation to the flat majority regardless of population size.
- **Trimmed correspondence**: a distance cap (auto: `0.15×` the reference bbox diagonal, or caller-supplied) plus an additional worst-`trimFraction` residual trim each iteration — robust to partial overlap between the two meshes.
- Low's (2004) linearized point-to-plane solve for the incremental 6-DOF rigid transform each iteration, via `Linalg.solve` (reusing the same generic Gaussian-elimination solver `PrimitiveFitter` uses, just at 6×6).
- A minimal internal k-d tree (`KDTree3.swift`, not part of the public API) backs nearest-neighbor correspondence search.
- Deterministic throughout: k-d tree median-split ties, normal-space sampling's bucket order, trimmed-correspondence ties, and PCA pre-align's 4 candidate order are all fixed/tie-broken explicitly.
- Returns `nil` for degenerate input (either mesh has fewer than 3 points after welding) rather than a meaningless transform.
- `docs/algorithms/alignment.md` — algorithm writeup, why point-to-plane needs a good starting pose, sign/rotation conventions.
- Version bump 1.3.0 → 1.4.0 (new algorithm, per this repo's release convention). **Note:** this PR and #24 (`vertexCurvatures()`, also #23) both branch from the same `main` and both bump to 1.4.0 independently — whichever merges second will need to bump to 1.5.0 to avoid a version collision; flagging for whoever merges these.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 67/67 passing, including 6 new alignment tests:
  - Known-transform recovery (asymmetric bumpy-surface fixture, non-periodic to avoid a repeating-surface aliasing pitfall discovered while writing the partial-overlap test — documented inline)
  - Partial overlap (60% overlap between two same-footprint patches) converges to the correct region, not a wrong-but-plausible one
  - Normal-space sampling: a dedicated deterministic test proves a minority feature-normal bucket gets picked while uniform even-stride sampling at the same budget misses it entirely (with an off-diagonal bump placement — a centered bump would alias with the raster stride path on a regular grid, which was a real pitfall this test previously tripped over)
  - End-to-end: normal-space sampling recovers an in-plane translation on a flat+small-feature mesh (the motivating case — a truly flat plane can't disambiguate in-plane translation via point-to-plane residual alone)
  - Determinism (bit-identical repeated calls)
  - Degenerate input (< 3 points) returns `nil`

🤖 Generated with [Claude Code](https://claude.com/claude-code)